### PR TITLE
admin/adopy-mypy-type-checking

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -68,6 +68,9 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 cdp_backend --count --verbose --show-source --statistics
+    - name: Check typing with mypy
+      run: |
+        mypy cdp_backend
     - name: Check with black
       run: |
         black --check cdp_backend

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 cdp_backend --count --verbose --show-source --statistics
+    - name: Check typing with mypy
+      run: |
+        mypy cdp_backend
     - name: Check with black
       run: |
         black --check cdp_backend

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help
+.PHONY: clean build gen-docs docs help
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ clean:  ## clean all build, python, and testing files
 	rm -fr coverage.xml
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
+	rm -fr .mypy_cache
 
 build: ## run tox / run tests and lint
 	tox

--- a/cdp_backend/__init__.py
+++ b/cdp_backend/__init__.py
@@ -9,5 +9,5 @@ __email__ = "jmaxfieldbrown@gmail.com"
 __version__ = "3.0.0.dev1"
 
 
-def get_module_version():
+def get_module_version() -> str:
     return __version__

--- a/cdp_backend/bin/create_cdp_database_uml.py
+++ b/cdp_backend/bin/create_cdp_database_uml.py
@@ -24,10 +24,10 @@ log = logging.getLogger(__name__)
 
 
 class Args(argparse.Namespace):
-    def __init__(self):
+    def __init__(self) -> None:
         self.__parse()
 
-    def __parse(self):
+    def __parse(self) -> None:
         p = argparse.ArgumentParser(
             prog="create_cdp_database_uml", description="Create a CDP UML dot file."
         )
@@ -45,7 +45,7 @@ class Args(argparse.Namespace):
 ###############################################################################
 
 
-def _construct_dot_file(output_file: str):
+def _construct_dot_file(output_file: str) -> str:
     dot = Digraph(
         comment="CDP Database Diagram",
         graph_attr={
@@ -115,8 +115,10 @@ def _construct_dot_file(output_file: str):
     # Save file
     dot.save(str(output_file))
 
+    return output_file
 
-def main():
+
+def main() -> None:
     try:
         args = Args()
         _construct_dot_file(output_file=args.output_file)

--- a/cdp_backend/database/exceptions.py
+++ b/cdp_backend/database/exceptions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from fireo.models import Model
 
@@ -9,20 +9,20 @@ from fireo.models import Model
 
 
 class UniquenessError(Exception):
-    def __init__(self, model: Model, conflicting_results: List[Dict]):
+    def __init__(self, model: Model, conflicting_results: List[Model]):
         super().__init__()
         self.model = model
         self.conflicting_results = conflicting_results
 
     @property
-    def pk_values(self):
+    def pk_values(self) -> Dict[str, Any]:
         return {pk: getattr(self.model, pk) for pk in self.model._PRIMARY_KEYS}
 
     @property
-    def conflicting_ids(self):
+    def conflicting_ids(self) -> List[str]:
         return [r.id for r in self.conflicting_results]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"Uniqueness constraint failed for {self.model.collection_name}. "
             f"Found {len(self.conflicting_results)} for values: {self.pk_values}. "

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -24,7 +24,7 @@ class File(Model):
     media_type = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         uri = "gs://cdp-example/central-staff-memo.pdf"
         file = cls()
         file.uri = uri
@@ -52,7 +52,7 @@ class Person(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         person = cls()
         person.name = "M. Lorena González"
         person.router_string = "lorena-gonzalez"
@@ -81,7 +81,7 @@ class Body(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         body = cls()
         body.name = "Full Council"
         body.is_active = True
@@ -104,7 +104,7 @@ class Seat(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         seat = cls()
         seat.name = "Position 9"
         seat.electoral_area = "Citywide"
@@ -134,7 +134,7 @@ class Role(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         role = cls()
         role.title = "Council President"
         role.person_ref = Person.Example()
@@ -158,7 +158,7 @@ class Matter(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         matter = cls()
         matter.name = "CB 119858"
         matter.matter_type = "Council Bill"
@@ -199,7 +199,7 @@ class MatterStatus(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         matter_status = cls()
         matter_status.matter_ref = Matter.Example()
         matter_status.status = "Passed"
@@ -236,7 +236,7 @@ class MatterFile(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         matter_file = cls()
         matter_file.matter_ref = Matter.Example()
         matter_file.name = "Amendment 3 (Sawant) - Sunset"
@@ -267,7 +267,7 @@ class MatterSponsor(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         matter_sponsor = cls()
         matter_sponsor.matter_ref = Matter.Example()
         matter_sponsor.person_ref = Person.Example()
@@ -289,7 +289,7 @@ class MinutesItem(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         minutes_item = cls()
         minutes_item.name = "Inf 1656"
         minutes_item.description = (
@@ -316,7 +316,7 @@ class Event(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         event = cls()
         event.body_ref = Body.Example()
         event.event_datetime = datetime.utcnow()
@@ -361,7 +361,7 @@ class Session(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         session = cls()
         session.event_ref = Event.Example()
         session.session_index = 0
@@ -385,7 +385,7 @@ class Transcript(Model):
     created = fields.DateTime(required=True)
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         transcript = cls()
         transcript.session_ref = Session.Example()
         transcript.file_ref = File.Example()
@@ -422,7 +422,7 @@ class EventMinutesItem(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         emi = cls()
         emi.event_ref = Event.Example()
         emi.minutes_item_ref = MinutesItem.Example()
@@ -458,7 +458,7 @@ class EventMinutesItemFile(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         emif = cls()
         emif.event_minutes_item_ref = EventMinutesItem.Example()
         emif.name = "Levy to Move Seattle Quartly Report"
@@ -491,7 +491,7 @@ class Vote(Model):
     external_source_id = fields.TextField()
 
     @classmethod
-    def Example(cls):
+    def Example(cls) -> Model:
         vote = cls()
         vote.matter_ref = Matter.Example()
         vote.event_ref = Event.Example()

--- a/cdp_backend/database/types.py
+++ b/cdp_backend/database/types.py
@@ -17,4 +17,4 @@ class IndexedField(NamedTuple):
 
 
 class IndexedFieldSet(NamedTuple):
-    fields: Tuple[IndexedField]
+    fields: Tuple[IndexedField, IndexedField]

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -13,7 +13,7 @@ from . import exceptions
 # Model Validation
 
 
-def model_is_unique(model: Model):
+def model_is_unique(model: Model) -> None:
     """
     Validate that the primary keys of a to-be-uploaded model are unique when compared
     to the collection.

--- a/cdp_backend/infrastructure/cdp_stack.py
+++ b/cdp_backend/infrastructure/cdp_stack.py
@@ -88,10 +88,10 @@ class CDPStack(pulumi.ComponentResource):
             for idx_field_set in model_cls._INDEXES:
 
                 # Add fields to field list
-                idx_set_name = []
+                idx_set_name_parts = []
                 idx_set_fields = []
                 for idx_field in idx_field_set.fields:
-                    idx_set_name += [idx_field.name, idx_field.order]
+                    idx_set_name_parts += [idx_field.name, idx_field.order]
                     idx_set_fields.append(
                         {
                             "fieldPath": idx_field.name,
@@ -100,11 +100,11 @@ class CDPStack(pulumi.ComponentResource):
                     )
 
                 # Finish creating the index set name
-                idx_set_name = "_".join(idx_set_name)
-                idx_set_name = f"{model_cls.collection_name}-{idx_set_name}"
+                idx_set_name = "_".join(idx_set_name_parts)
+                fq_idx_set_name = f"{model_cls.collection_name}-{idx_set_name}"
 
                 gcp.firestore.Index(
-                    idx_set_name,
+                    fq_idx_set_name,
                     collection=model_cls.collection_name,
                     fields=idx_set_fields,
                     project=self.gcp_project_id,

--- a/cdp_backend/tests/database/test_models.py
+++ b/cdp_backend/tests/database/test_models.py
@@ -12,7 +12,7 @@ from cdp_backend.database import DATABASE_MODELS
 ###############################################################################
 
 
-def test_validate_model_definitions():
+def test_validate_model_definitions() -> None:
     for model_cls in DATABASE_MODELS:
         assert hasattr(model_cls, "Example")
         assert hasattr(model_cls, "_PRIMARY_KEYS")
@@ -44,7 +44,7 @@ def test_validate_model_definitions():
                         assert hasattr(m, idx_field.name)
 
 
-def test_cdp_database_model_has_no_cyclic_dependencies(tmpdir):
+def test_cdp_database_model_has_no_cyclic_dependencies(tmpdir: Path) -> None:
     # Minor edits to:
     # https://blog.jasonantman.com/2012/03/python-script-to-find-dependency-cycles-in-graphviz-dot-files/
 

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -2,9 +2,11 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from typing import List
 from unittest import mock
 
 from cdp_backend.database import models, validators, exceptions
+from fireo.models import Model
 
 from .. import test_utils
 
@@ -32,7 +34,10 @@ from .. import test_utils
         ),
     ],
 )
-def test_uniqueness_validation(model_name, mock_return_values):
+def test_uniqueness_validation(
+    model_name: str,
+    mock_return_values: List[Model],
+) -> None:
     with mock.patch("fireo.queries.filter_query.FilterQuery.fetch") as mocked_fetch:
         mocked_fetch.return_value = mock_return_values
 
@@ -58,7 +63,7 @@ def test_uniqueness_validation(model_name, mock_return_values):
         ("lorena gonzalez", False),
     ],
 )
-def test_router_string_is_valid(router_string, expected_result):
+def test_router_string_is_valid(router_string: str, expected_result: bool) -> None:
     actual_result = validators.router_string_is_valid(router_string)
     assert actual_result == expected_result
 
@@ -76,7 +81,7 @@ def test_router_string_is_valid(router_string, expected_result):
         ("Lorena.González@seattle.gov", False),
     ],
 )
-def test_email_is_valid(email, expected_result):
+def test_email_is_valid(email: str, expected_result: bool) -> None:
     actual_result = validators.email_is_valid(email)
     assert actual_result == expected_result
 
@@ -89,13 +94,13 @@ def test_email_is_valid(email, expected_result):
         ("file://does-not-exist.txt", False),
     ],
 )
-def test_local_resource_exists(uri, expected_result):
+def test_local_resource_exists(uri: str, expected_result: bool) -> None:
     actual_result = validators.resource_exists(uri)
     assert actual_result == expected_result
 
 
 @pytest.mark.skipif(
-    not test_utils.check_internet_available(),
+    not test_utils.internet_is_available(),
     reason="No internet connection",
 )
 @pytest.mark.parametrize(
@@ -106,6 +111,6 @@ def test_local_resource_exists(uri, expected_result):
         ("https://docs.pytest.org/en/latest/does-not-exist.html", False),
     ],
 )
-def test_remote_resource_exists(uri, expected_result):
+def test_remote_resource_exists(uri: str, expected_result: bool) -> None:
     actual_result = validators.resource_exists(uri)
     assert actual_result == expected_result

--- a/cdp_backend/tests/infrastructure/test_cdp_stack.py
+++ b/cdp_backend/tests/infrastructure/test_cdp_stack.py
@@ -1,28 +1,36 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from typing import Any, Dict, List, Optional, Tuple
 import unittest
-import pulumi
 
 from cdp_backend.infrastructure import CDPStack
+import pulumi
 
 ###############################################################################
 
 
 # Create the various mocks.
 class CDPStackMocks(pulumi.runtime.Mocks):
-    def call(self, token, args, provider):
+    def call(self, token: str, args: Any, provider: Optional[str]) -> Dict:
         return {}
 
-    def new_resource(self, type_, name, inputs, provider, id_):
+    def new_resource(
+        self,
+        type_: str,
+        name: str,
+        inputs: Any,
+        provider: Optional[str],
+        id_: Optional[str],
+    ) -> Tuple[str, Dict[Any, Any]]:
         if type_ == "gcp:appengine/application:Application":
             state = {
                 "app_id": f"{name}.fake-appspot.io",
                 "default_bucket": f"gcs://{name}",
             }
-            return [name, dict(inputs, **state)]
+            return (name, dict(inputs, **state))
 
-        return ["", {}]
+        return ("", {})
 
 
 pulumi.runtime.set_mocks(CDPStackMocks())
@@ -32,15 +40,15 @@ pulumi.runtime.set_mocks(CDPStackMocks())
 
 class InfrastructureTests(unittest.TestCase):
     @pulumi.runtime.test
-    def test_basic_run(self):
+    def test_basic_run(self) -> None:
         gcp_project_id = "mocked-testing-stack"
 
         # Write output checks
-        def check_firestore_app_id(args):
+        def check_firestore_app_id(args: List[Any]) -> None:
             app_id = args
             assert app_id == f"{gcp_project_id}.fake-appspot.io"
 
-        def check_firestore_default_bucket(args):
+        def check_firestore_default_bucket(args: List[Any]) -> None:
             default_bucket = args
             assert default_bucket == f"gcs://{gcp_project_id}"
 

--- a/cdp_backend/tests/test_utils.py
+++ b/cdp_backend/tests/test_utils.py
@@ -6,7 +6,11 @@ import socket
 #############################################################################
 
 
-def check_internet_available(host="8.8.8.8", port=53, timeout=3):
+def internet_is_available(
+    host: str = "8.8.8.8",
+    port: int = 53,
+    timeout: int = 3,
+) -> bool:
     """
     Host: 8.8.8.8 (google-public-dns-a.google.com)
     OpenPort: 53/tcp

--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from typing import Optional
 
 from cdp_backend.utils import file_utils
 
@@ -25,6 +26,6 @@ from cdp_backend.utils import file_utils
         ("file:///some/dir/image.unknownformat", None),
     ],
 )
-def test_get_media_type(uri, expected_result):
+def test_get_media_type(uri: str, expected_result: Optional[str]) -> None:
     actual_result = file_utils.get_media_type(uri)
     assert actual_result == expected_result

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,16 @@ test = pytest
 collect_ignore = ['setup.py']
 
 [flake8]
-exclude = 
+exclude =
 	docs/
-ignore = 
+ignore =
 	E203
 	E402
 	W291
 	W503
 max-line-length = 88
+
+[mypy]
+ignore_missing_imports = True
+disallow_untyped_defs = True
+check_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ test_requirements = [
     "codecov>=2.1.4",
     "flake8>=3.8.3",
     "flake8-debugger>=3.2.1",
+    "mypy>=0.790",
     "networkx>=2.5",
     "pydot>=1.4",
     "pytest>=5.4.3",

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     .[test]
 commands =
     flake8 cdp_backend --count --verbose --show-source --statistics
+    mypy cdp_backend
     black --check cdp_backend
 
 [testenv]


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #18 

- [x] Provide context of changes.

Adopts MyPy for type checking. While sometimes annoying, in the long run a good move to maintain the repo across multiple devs + PRs and such.

Note:
There are some changes in here that relate to mypy type checking, notably, the one that threw me off was mypy will try to use the same typing over the same variable at it's first initialization. Example:
```python
def use_some_string(s: str) -> Any:
    ...

some_string = ["jack", "son"]
some_string = "".join(some_string)
use_some_string(some_string)
```

`mypy` will complain because I initialized `some_string` as `List[str]` but then later used it as a `str`. This should basically just teach me to use better naming conventions.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
