### PR TITLE
feature/model-validator-fix-and-update

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -82,21 +82,3 @@ jobs:
     - name: Generate Docs
       run: |
         make gen-docs
-
-  # Preview infrastructure changes for cdp-example
-  pulumi-preview:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install graphviz
-        run: |
-          sudo apt-get install graphviz
-      - name: Run Pulumi Preview
-        uses: docker://pulumi/actions
-        with:
-          args: preview
-        env:
-          GOOGLE_CREDENTIALS: ${{ secrets.CDP_EXAMPLE_GOOGLE_CREDENTIALS }}
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_CI: pr
-          PULUMI_ROOT: example-infrastructure

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -29,8 +29,8 @@ class UniquenessValidation:
     """
     An object containing uniqueness data of a database model object.
 
-    Notes
-    -----
+    Parameters
+    ----------
     is_unique is a boolean on whether the model is unique by primary key
     in the database collection.
 
@@ -42,7 +42,7 @@ class UniquenessValidation:
     conflicting_models: List[Model]
 
 
-def model_is_unique(model: Model) -> UniquenessValidation:
+def get_model_uniqueness(model: Model) -> UniquenessValidation:
     """
     Validate that the primary keys of a to-be-uploaded model are unique
     when compared to the collection.
@@ -60,10 +60,11 @@ def model_is_unique(model: Model) -> UniquenessValidation:
     Examples
     --------
     >>> from cdp_backend.database import models
-    ... from cdp_backend.database.validators import model_is_unique
+    ... from cdp_backend.database.validators import get_model_uniqueness
     ...
     ... b = models.Body.Example()
-    ... if model_is_unique(b):
+    ... b_uniqueness = get_model_uniqueness(b)
+    ... if b_uniqueness.is_unique:
     ...     b.save()
     """
     # Initialize query

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -3,7 +3,8 @@
 
 import logging
 import re
-from typing import Optional
+from typing import List, Optional
+from dataclasses import dataclass
 
 from fireo.models import Model
 from fsspec.core import url_to_fs
@@ -23,10 +24,28 @@ log = logging.getLogger(__name__)
 # Model Validation
 
 
-def model_is_unique(model: Model) -> bool:
+@dataclass(frozen=True)
+class UniquenessValidation:
     """
-    Validate that the primary keys of a to-be-uploaded model are unique when compared
-    to the collection.
+    An object containing uniqueness data of a database model object.
+
+    Notes
+    -----
+    is_unique is a boolean on whether the model is unique by primary key
+    in the database collection.
+
+    conflicting_models is a List[Model] of all existing models that share
+    the same primary keys as the input model.
+    """
+
+    is_unique: bool
+    conflicting_models: List[Model]
+
+
+def model_is_unique(model: Model) -> UniquenessValidation:
+    """
+    Validate that the primary keys of a to-be-uploaded model are unique
+    when compared to the collection.
 
     Parameters
     ----------
@@ -35,8 +54,8 @@ def model_is_unique(model: Model) -> bool:
 
     Returns
     -------
-    is_unique: bool
-        Boolean representing if the model is unique in the collection.
+    uniqueness_validation: UniquenessValidation
+        An object that contains data on an objects uniqueness and conflicting models.
 
     Examples
     --------
@@ -52,15 +71,19 @@ def model_is_unique(model: Model) -> bool:
 
     # Loop and fill query for each primary key
     for pk in model._PRIMARY_KEYS:
-        query = query.filter(pk, "==", getattr(model, pk))
+        field = getattr(model, pk)
+        if issubclass(field.__class__, Model):
+            query = query.filter(pk, "==", field.key)
+        else:
+            query = query.filter(pk, "==", field)
 
     # Fetch and assert single value
     results = list(query.fetch())
     if len(results) >= 1:
         log.info(f"Found conflicting results={results} for model={model}.")
-        return False
+        return UniquenessValidation(is_unique=False, conflicting_models=results)
 
-    return True
+    return UniquenessValidation(is_unique=True, conflicting_models=results)
 
 
 #############################################################################

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -31,11 +31,12 @@ class UniquenessValidation:
 
     Parameters
     ----------
-    is_unique is a boolean on whether the model is unique by primary key
-    in the database collection.
+    is_unique: bool
+        A boolean on whether the model is unique by primary key
+        in the database collection.
 
-    conflicting_models is a List[Model] of all existing models that share
-    the same primary keys as the input model.
+    conflicting_models: List[Model]
+        All existing models that share the same primary keys as the input model.
     """
 
     is_unique: bool

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -6,6 +6,7 @@ from typing import List
 from unittest import mock
 
 from cdp_backend.database import models, validators
+from cdp_backend.database.validators import UniquenessValidation
 from fireo.models import Model
 
 from .. import test_utils
@@ -13,20 +14,48 @@ from .. import test_utils
 #############################################################################
 
 
+"""
+Uniqueness test constants 
+
+Defined because Example() uses datetime.utcnow() which interferes 
+with uniqueness testing
+"""
+body = models.Body.Example()
+person = models.Person.Example()
+event = models.Event.Example()
+
+
 @pytest.mark.parametrize(
     "model_name, mock_return_values, expected",
     [
-        ("Body", [], True),
-        ("Person", [], True),
-        ("Body", [models.Body.Example()], False),
-        ("Body", [models.Body.Example(), models.Body.Example()], False),
-        ("Person", [models.Person.Example()], False),
+        ("Body", [], UniquenessValidation(True, [])),
+        ("Person", [], UniquenessValidation(True, [])),
+        (
+            "Body",
+            [body],
+            UniquenessValidation(False, [body]),
+        ),
+        (
+            "Body",
+            [body, body],
+            UniquenessValidation(False, [body, body]),
+        ),
+        (
+            "Person",
+            [person],
+            UniquenessValidation(False, [person]),
+        ),
+        (
+            "Event",
+            [event],
+            UniquenessValidation(False, [event]),
+        ),
     ],
 )
 def test_uniqueness_validation(
     model_name: str,
     mock_return_values: List[Model],
-    expected: bool,
+    expected: UniquenessValidation,
 ) -> None:
     with mock.patch("fireo.queries.filter_query.FilterQuery.fetch") as mocked_fetch:
         mocked_fetch.return_value = mock_return_values

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -67,7 +67,7 @@ def test_uniqueness_validation(
         instance = spec.Example()
 
         # Validate
-        assert expected == validators.model_is_unique(instance)
+        assert expected == validators.get_model_uniqueness(instance)
 
 
 @pytest.mark.parametrize(

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ dev_requirements = [
 
 requirements = [
     "dask[bag]~=2.30.0",
-    "fireo~=1.3.3",
+    "fireo~=1.3.7",
     "fsspec~=0.8.3",
     "gcsfs~=0.7.1",
     "graphviz~=0.14",


### PR DESCRIPTION
* Fixed query building bug when primary key is another Model/ReferenceField

* Create class for validation output and add conflicting model results

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
 - Relevant to #16 
- [x] Provide context of changes.
 - Query was erroring out in `is_model_unique` when we were filtering by a `ReferenceField` (when querying something like `Event` which has `Body` as a primary key.
 - Fixed how we build the query because the way that the queries are built for `fireo` [is different when you want to filter by a `ReferenceField`](https://octabyte.io/FireO/querying-data/querying-and-filtering/#filter-with-reference-model), and this was only [recently added in 1.3.7](https://github.com/octabytes/FireO/releases/tag/v1.3.7). 
 - Added `UniquenessValidation` object because in the event gather pipeline we want to retrieve the existing db model(s) if it exists (Ex. if `Body` exists, we want to use that model as a `ReferenceField` in the `Event`). This way we can properly build the db models bottom-up from the ingestion models without having to make extra queries to the database.
- [x] Provide relevant tests for your feature or bug fix.
 - Added test case for `Event` since it has a `ReferenceField` primary key
 - Manually tested that this works
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
