### PR TITLE
feature/add-matter-status-constants

### DIFF
--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -12,6 +12,7 @@ from .types import (
     EventMinutesItemDecision,
     IndexedField,
     IndexedFieldSet,
+    MatterStatusDecision,
     Order,
     VoteDecision,
 )
@@ -198,7 +199,12 @@ class MatterStatus(Model):
     """
 
     matter_ref = fields.ReferenceField(Matter, required=True)
-    status = fields.TextField(required=True)
+    status = fields.TextField(
+        required=True,
+        validator=validators.create_constant_value_validator(
+            MatterStatusDecision, True
+        ),
+    )
     update_datetime = fields.DateTime(required=True)
     external_source_id = fields.TextField()
 
@@ -206,7 +212,7 @@ class MatterStatus(Model):
     def Example(cls) -> Model:
         matter_status = cls()
         matter_status.matter_ref = Matter.Example()
-        matter_status.status = "Passed"
+        matter_status.status = MatterStatusDecision.ADOPTED
         matter_status.update_datetime = datetime.utcnow()
         return matter_status
 
@@ -423,7 +429,9 @@ class EventMinutesItem(Model):
     minutes_item_ref = fields.ReferenceField(MinutesItem, required=True)
     index = fields.NumberField(required=True)
     decision = fields.TextField(
-        validator=validators.event_minutes_item_decision_is_valid
+        validator=validators.create_constant_value_validator(
+            EventMinutesItemDecision, False
+        )
     )
     external_source_id = fields.TextField()
 
@@ -495,7 +503,8 @@ class Vote(Model):
     event_minutes_item_ref = fields.ReferenceField(EventMinutesItem, required=True)
     person_ref = fields.ReferenceField(Person, required=True)
     decision = fields.TextField(
-        required=True, validator=validators.vote_decision_is_valid
+        required=True,
+        validator=validators.create_constant_value_validator(VoteDecision, True),
     )
     in_majority = fields.BooleanField(required=True)
     external_source_id = fields.TextField()

--- a/cdp_backend/database/types.py
+++ b/cdp_backend/database/types.py
@@ -29,3 +29,9 @@ class VoteDecision:
     APPROVE = "Approve"
     REJECT = "Reject"
     ABSTAIN = "Abstain"
+
+
+class MatterStatusDecision:
+    ADOPTED = "Adopted"
+    REJECTED = "Rejected"
+    IN_PROGRESS = "In Progress"

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -3,14 +3,13 @@
 
 import logging
 import re
-from typing import List, Optional
+from typing import Callable, List, Optional, Type
 from dataclasses import dataclass
 
 from fireo.models import Model
 from fsspec.core import url_to_fs
 
 from ..utils.constants_utils import get_all_class_attr_values
-from .types import EventMinutesItemDecision, VoteDecision
 
 ###############################################################################
 
@@ -173,41 +172,41 @@ def resource_exists(uri: Optional[str]) -> bool:
     return False
 
 
-def vote_decision_is_valid(decision: str) -> bool:
+def create_constant_value_validator(
+    constant_cls: Type, is_required: bool
+) -> Callable[[str], bool]:
     """
-    Validate that vote's decision is valid.
-
-    None is not a valid option.
+    Create a validator func that validates a value is one of the valid values.
 
     Parameters
     ----------
-    decision: str
-        The decision to validate.
+    constant_cls: Type
+        The constant class that contains the valid values.
+    is_required: bool
+        Whether the value is required.
 
     Returns
     -------
-    status: bool
-        The validation status.
+    validator_func: Callable[[str], bool]
+        The validator func.
     """
-    return decision in get_all_class_attr_values(VoteDecision)
 
+    def is_valid(value: str) -> bool:
+        """
+        Validate that value is valid.
 
-def event_minutes_item_decision_is_valid(decision: Optional[str]) -> bool:
-    """
-    Validate that event minutes item's decision is valid.
+        Parameters
+        ----------
+        value: str
+            The value to validate.
 
-    None is a valid option.
+        Returns
+        -------
+        status: bool
+            The validation status.
+        """
+        if value is None:
+            return not is_required
+        return value in get_all_class_attr_values(constant_cls)
 
-    Parameters
-    ----------
-    decision: Optional[str]
-        The decision to validate.
-
-    Returns
-    -------
-    status: bool
-        The validation status.
-    """
-    if decision:
-        return decision in get_all_class_attr_values(EventMinutesItemDecision)
-    return True
+    return is_valid

--- a/cdp_backend/pipeline/ingestion_models.py
+++ b/cdp_backend/pipeline/ingestion_models.py
@@ -97,7 +97,7 @@ class Matter:
     name: str
     matter_type: str
     title: str
-    status: str
+    result_status: str
     sponsors: Optional[List[Person]] = None
     external_source_id: Optional[str] = None
 
@@ -258,7 +258,7 @@ EXAMPLE_FILLED_EVENT = EventIngestionModel(
                 title=(
                     "AN ORDINANCE relating to the financing of the West Seattle Bridge"
                 ),
-                status="Adopted",
+                result_status="Adopted",
                 sponsors=[
                     Person(
                         name="M. Lorena González",

--- a/cdp_backend/pipeline/ingestion_models.py
+++ b/cdp_backend/pipeline/ingestion_models.py
@@ -97,6 +97,7 @@ class Matter:
     name: str
     matter_type: str
     title: str
+    status: str
     sponsors: Optional[List[Person]] = None
     external_source_id: Optional[str] = None
 
@@ -257,6 +258,7 @@ EXAMPLE_FILLED_EVENT = EventIngestionModel(
                 title=(
                     "AN ORDINANCE relating to the financing of the West Seattle Bridge"
                 ),
+                status="Adopted",
                 sponsors=[
                     Person(
                         name="M. Lorena González",

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import pytest
 from typing import List
 from unittest import mock
 
-from cdp_backend.database import models, validators
-from cdp_backend.database.validators import UniquenessValidation
+import pytest
 from fireo.models import Model
+
+from cdp_backend.database import models, validators
+from cdp_backend.database.types import (
+    EventMinutesItemDecision,
+    MatterStatusDecision,
+    VoteDecision,
+)
+from cdp_backend.database.validators import UniquenessValidation
 
 from .. import test_utils
 
@@ -144,7 +150,8 @@ def test_remote_resource_exists(uri: str, expected_result: bool) -> None:
     ],
 )
 def test_vote_decision_is_valid(decision: str, expected_result: bool) -> None:
-    actual_result = validators.vote_decision_is_valid(decision)
+    validator_func = validators.create_constant_value_validator(VoteDecision, True)
+    actual_result = validator_func(decision)
     assert actual_result == expected_result
 
 
@@ -159,5 +166,24 @@ def test_vote_decision_is_valid(decision: str, expected_result: bool) -> None:
 def test_event_minutes_item_decision_is_valid(
     decision: str, expected_result: bool
 ) -> None:
-    actual_result = validators.event_minutes_item_decision_is_valid(decision)
+    validator_func = validators.create_constant_value_validator(
+        EventMinutesItemDecision, False
+    )
+    actual_result = validator_func(decision)
+    assert actual_result == expected_result
+
+
+@pytest.mark.parametrize(
+    "decision, expected_result",
+    [
+        (None, False),
+        ("Adopted", True),
+        ("INVALID", False),
+    ],
+)
+def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -> None:
+    validator_func = validators.create_constant_value_validator(
+        MatterStatusDecision, True
+    )
+    actual_result = validator_func(decision)
     assert actual_result == expected_result


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- Add useful matter status constants for `MatterStatus` database model. The constants are `Adopted`, `Rejected`, and `In Progress`.
- Provide validators for them in the database models. Instead of creating a validator for each constant class, I created a factory function that creates the validator to avoid duplication.
- Also added `status` to the `Matter` ingestion model. I decided to put it there to follow the `sponsors` example. Similar to how `sponsors` will be used to create/update `MatterSponsor`, `status` will be used to create/update `MatterStatus` in the pipeline.
- [x] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
