### PR TITLE
admin/typos-in-pypi-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tooling.
 
 ## Installation
 
-**Stable Release:** `pip install cdp_backend`<br>
+**Stable Release:** `pip install cdp-backend`<br>
 **Development Head:** `pip install git+https://github.com/CouncilDataProject/cdp-backend.git`<br>
 
 **Dev Installation:**

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ To install cdp-backend, run this command in your terminal:
 
 .. code-block:: console
 
-    $ pip install cdp_backend
+    $ pip install cdp-backend
 
 This is the preferred method to install cdp-backend, as it will always install the most recent stable release.
 


### PR DESCRIPTION
In README and installation the package was listed as `cdp_backend` when it should be `cdp-backend`