### PR TITLE
feature/generate-event-gather-flow-viz-docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,5 @@ ENV/
 
 # Project specific
 cdp_database_diagram.*
+cdp_event_gather_flow_*
 event_data_ingestion_model.md

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ gen-docs: ## generate Sphinx HTML documentation, including API docs
 	create_cdp_database_uml -o docs/_static/cdp_database_diagram.dot
 	dot -T png -o docs/_static/cdp_database_diagram.png docs/_static/cdp_database_diagram.dot
 	create_cdp_ingestion_model_doc -t docs/event_data_ingestion_model.template -o docs/event_data_ingestion_model.md
+	create_cdp_event_gather_flow_viz -o docs/_static/cdp_event_gather_flow_{ftype}.png
 	sphinx-apidoc -o docs/ cdp_backend **/tests/
 	$(MAKE) -C docs html
 

--- a/cdp_backend/bin/cdp_event_gather.py
+++ b/cdp_backend/bin/cdp_event_gather.py
@@ -9,7 +9,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import Callable
 
-from ..pipeline import cdp_event_gather_pipeline as pipeline
+from cdp_backend.pipeline import cdp_event_gather_pipeline as pipeline
 
 ###############################################################################
 
@@ -34,7 +34,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "-g",
             "--google-credentials-file",
-            default=(Path(__file__).parent.parent.parent / "cdp-dev-infra-creds.json"),
+            default=(Path(__file__).parent.parent.parent / "cdp-creds.json"),
             type=Path,
             dest="google_credentials_file",
             help="Path to the Google Service Account Credentials JSON file.",

--- a/cdp_backend/bin/create_cdp_event_gather_flow_viz.py
+++ b/cdp_backend/bin/create_cdp_event_gather_flow_viz.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import logging
+import sys
+import traceback
+from pathlib import Path
+from typing import List
+
+from cdp_backend.pipeline import cdp_event_gather_pipeline as pipeline
+from cdp_backend.pipeline.ingestion_models import (
+    EXAMPLE_FILLED_EVENT,
+    EXAMPLE_MINIMAL_EVENT,
+    EventIngestionModel,
+)
+
+###############################################################################
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)4s: %(module)s:%(lineno)4s %(asctime)s] %(message)s",
+)
+log = logging.getLogger(__name__)
+
+###############################################################################
+
+
+class Args(argparse.Namespace):
+    def __init__(self) -> None:
+        self.__parse()
+
+    def __parse(self) -> None:
+        p = argparse.ArgumentParser(
+            prog="cdp_event_gather",
+            description="Gather, process, and store event data to CDP infrastructure.",
+        )
+        p.add_argument(
+            "-o",
+            "--output-file-spec",
+            type=Path,
+            default=Path("cdp_event_gather_flow_{ftype}.png"),
+            dest="output_file",
+            help=(
+                "Path spec to where to store the created PNG files. "
+                "Use `{ftype}` as the formatted spec parameter."
+            ),
+        )
+        p.parse_args(namespace=self)
+
+
+def fake_get_events_minimal() -> List[EventIngestionModel]:
+    return [EXAMPLE_MINIMAL_EVENT]
+
+
+def fake_get_events_filled() -> List[EventIngestionModel]:
+    return [EXAMPLE_FILLED_EVENT]
+
+
+def fake_get_events_many() -> List[EventIngestionModel]:
+    return [EXAMPLE_MINIMAL_EVENT] * 4
+
+
+def main() -> None:
+    try:
+        args = Args()
+        minimal_flow = pipeline.create_cdp_event_gather_flow(
+            fake_get_events_minimal, ""
+        )
+        minimal_flow.visualize(
+            filename=str(args.output_file.with_suffix("")).format(ftype="minimal"),
+            format="png",
+        )
+
+        filled_flow = pipeline.create_cdp_event_gather_flow(fake_get_events_filled, "")
+        filled_flow.visualize(
+            filename=str(args.output_file.with_suffix("")).format(ftype="filled"),
+            format="png",
+        )
+
+        many_flow = pipeline.create_cdp_event_gather_flow(fake_get_events_many, "")
+        many_flow.visualize(
+            filename=str(args.output_file.with_suffix("")).format(ftype="many"),
+            format="png",
+        )
+
+    except Exception as e:
+        log.error("=============================================")
+        log.error("\n\n" + traceback.format_exc())
+        log.error("=============================================")
+        log.error("\n\n" + str(e) + "\n")
+        log.error("=============================================")
+        sys.exit(1)
+
+
+###############################################################################
+# Allow caller to directly run this module (usually in development scenarios)
+
+if __name__ == "__main__":
+    main()

--- a/cdp_backend/tests/pipeline/test_cdp_event_gather_pipeline.py
+++ b/cdp_backend/tests/pipeline/test_cdp_event_gather_pipeline.py
@@ -211,11 +211,14 @@ def test_upload_db_model(
                     else None
                 )
 
-                actual_uploaded_model = pipeline.upload_db_model.run(  # type: ignore
-                    db_model, ingestion_model
-                )
+                with mock.patch("fireo.connection") as mock_connector:
+                    mock_connector.return_value = None
 
-                assert_db_models_equality(expected, actual_uploaded_model, True)
+                    actual_uploaded_model = pipeline.upload_db_model.run(
+                        db_model, ingestion_model, creds_file=""  # type: ignore
+                    )
+
+                    assert_db_models_equality(expected, actual_uploaded_model, True)
 
 
 @pytest.mark.parametrize(

--- a/docs/event_gather_pipeline.md
+++ b/docs/event_gather_pipeline.md
@@ -1,0 +1,64 @@
+# Event Gather Pipeline
+
+Council Data Project documentation generally shortens the steps that the
+event gather pipeline takes into three short and easy to remember key points.
+
+1. **Gather Events**<br>
+   This function is created by each instance maintainer and
+   generally scrapes or requests data from an API and
+   returns a list of events to process and store.
+   [Learn more about the event ingestion model](./cdp-backend/event_data_ingestion_model.html)
+2. **Transcribe**<br>
+   If the event was provided with a closed caption file we clean the file up
+   into the CDP format, if not, CDP tools generate a transcription.
+3. **Index**<br>
+   An entirely different pipeline from the event gather pipeline but in
+   the context of the short and sweet version, this makes sense to include.
+   This is the pipeline that runs to generate and index using all the event
+   transcripts.
+
+These key points make sense from the thousand-foot-view, but is not
+satifactory for the developers and others who are simply interested in
+how the event gather pipeline works step-by-step.
+
+This document gives visualizations of each and every step the event gather
+pipeline takes, starting immediately after the maintainer provided function
+returns the `List[EventIngestionModel]`.
+
+### Minimal Event Processing
+
+Similar to the [event ingestion model](./cdp-backend/event_data_ingestion_model.html)
+documentation, if the event is provided back with only a URI to a
+video and nothing else, the processing is incredibly simple.
+
+![minimal cdp event gather flow viz](./_static/cdp_event_gather_flow_minimal.png)
+
+### Filled Event Processing
+
+The major difference from the minimal event processing workflow is that the
+pipeline will process, prepare, and upload all of the attachments.
+
+![filled cdp event gather flow viz](./_static/cdp_event_gather_flow_filled.png)
+
+### Workflow Management and Parallel Processing
+
+We utilize [Prefect Core](https://github.com/prefecthq/prefect) to generate and
+run the workflow. In general, and by default in our cookiecutter-cdp-deployment,
+we do not run any part of the workflow in parallel. But, this is simply because we
+generally don't need to. As all event gather pipelines are automated to run every day,
+or multiple times a day, it is rare for a pipeline to pick up more than one event
+to process.
+
+However, in the case where a maintainer is attempting to backfill large collections of
+events (i.e. processing historical events), we recommend attaching a
+[Dask Executor](https://docs.prefect.io/api/latest/executors.html#daskexecutor)
+to the flow for parallel event processing.
+[More details about Dask](https://dask.org/)
+
+I.E.
+If the result of the `get_events` function was a list of four
+`EventIngestionModel` objects, the resulting flow would look like the following:
+![parallel four wide equal minimal event flows](./_static/cdp_event_gather_flow_many.png)
+
+And, if a `DaskExecutor` is also provided, all single event processing workflows
+would process in parallel (provided enough compute resources).

--- a/docs/event_gather_pipeline.rst
+++ b/docs/event_gather_pipeline.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ./event_gather_pipeline.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Welcome to cdp-backend's documentation!
    installation
    Package Modules <modules>
    Event Data Ingestion Model <event_data_ingestion_model>
+   Event Gather Pipeline <event_gather_pipeline>
    Database Schema <database_schema>
    contributing
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ dev_requirements = [
     "ipython>=7.15.0",
     "jinja2>=2.11.2",
     "m2r>=0.2.1",
+    "prefect[viz]~=0.14.0",
     "pytest-runner>=5.2",
     "Sphinx>=2.0.0b1,<3",
     "sphinx_rtd_theme>=0.4.3",

--- a/setup.py
+++ b/setup.py
@@ -44,15 +44,15 @@ dev_requirements = [
 ]
 
 requirements = [
-    "dask[bag]~=2.30.0",
+    "dask[bag]~=2020.12.0",
     "fireo~=1.3.7",
     "fsspec~=0.8.3",
     "gcsfs~=0.7.1",
     "graphviz~=0.14",
     "pandas~=1.1.3",
+    "prefect~=0.14.0",
     "pulumi~=2.16.2",
     "pulumi-gcp~=4.6.0",
-    "prefect~=0.14.0"
 ]
 
 extra_requirements = {
@@ -87,6 +87,10 @@ setup(
             (
                 "create_cdp_ingestion_model_doc="
                 "cdp_backend.bin.create_ingestion_model_doc:main"
+            ),
+            (
+                "create_cdp_event_gather_flow_viz="
+                "cdp_backend.bin.create_cdp_event_gather_flow_viz:main"
             ),
             "cdp_event_gather=cdp_backend.bin.cdp_event_gather:main",
         ],


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #34 

- [x] Provide context of changes.

Minor changes to the event gather flow, most notably that the `fireo.connection` creation is ran during every `upload_db_model` task. This is done for two reasons:

1. If the user wanted to backfill and run in parallel, this would be required. (connections aren't shared across processes)
2. To the flow viz generation to be much simplier.

Adds another documentation file with multiple images of the event gather flow viz. @isaacna whenever you get around to adding more to the flow and expanding to processing, no worries, it will automatically generate the expanded flow using `EXAMPLE_FILLED_EVENT`.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
