### PR TITLE
feature/pass-datetimes-to-get-events-func

### DIFF
--- a/cdp_backend/bin/run_cdp_event_gather.py
+++ b/cdp_backend/bin/run_cdp_event_gather.py
@@ -43,6 +43,28 @@ class Args(argparse.Namespace):
             ),
         )
         p.add_argument(
+            "-f",
+            "--from",
+            type=str,
+            default=None,
+            help=(
+                "Optional ISO formatted string to pass to the get_event function to act"
+                "as the start point for event gathering."
+            ),
+            dest="from_dt",
+        )
+        p.add_argument(
+            "-t",
+            "--to",
+            type=str,
+            default=None,
+            help=(
+                "Optional ISO formatted string to pass to the get_event function to act"
+                "as the end point for event gathering."
+            ),
+            dest="to_dt",
+        )
+        p.add_argument(
             "-p",
             "--parallel",
             action="store_true",
@@ -65,7 +87,11 @@ def main() -> None:
             )
 
         # Get flow definition
-        flow = pipeline.create_event_gather_flow(config=config)
+        flow = pipeline.create_event_gather_flow(
+            config=config,
+            from_dt=args.from_dt,
+            to_dt=args.to_dt,
+        )
 
         # Determine executor
         if args.parallel:

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from importlib import import_module
 from operator import attrgetter
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 from fireo.fields.errors import FieldValidationFailed, InvalidFieldType, RequiredField
 from fsspec.core import url_to_fs
@@ -48,7 +48,11 @@ def import_get_events_func(func_path: str) -> Callable:
     return getattr(mod, func_name)
 
 
-def create_event_gather_flow(config: EventGatherPipelineConfig) -> Flow:
+def create_event_gather_flow(
+    config: EventGatherPipelineConfig,
+    from_dt: Optional[Union[str, datetime]] = None,
+    to_dt: Optional[Union[str, datetime]] = None,
+) -> Flow:
     """
     Provided a function to gather new event information, create the Prefect Flow object
     to preview, run, or visualize.
@@ -57,6 +61,14 @@ def create_event_gather_flow(config: EventGatherPipelineConfig) -> Flow:
     ----------
     config: EventGatherPipelineConfig
         Configuration options for the pipeline.
+    from_dt: Optional[Union[str, datetime]]
+        Optional ISO formatted string or datetime object to pass to the get_events
+        function to act as the start point for event gathering.
+        Default: None (two days ago)
+    to_dt: Optional[Union[str, datetime]]
+        Optional ISO formatted string or datetime object to pass to the get_events
+        function to act as the end point for event gathering.
+        Default: None (now)
 
     Returns
     -------
@@ -66,10 +78,35 @@ def create_event_gather_flow(config: EventGatherPipelineConfig) -> Flow:
     # Load get_events_func
     get_events_func = import_get_events_func(config.get_events_function_path)
 
+    # Handle from datetime
+    if isinstance(from_dt, str) and len(from_dt) != 0:
+        from_datetime = datetime.fromisoformat(from_dt)
+    elif isinstance(from_dt, datetime):
+        from_datetime = from_dt
+    else:
+        from_datetime = datetime.utcnow() - timedelta(days=2)
+
+    # Handle to datetime
+    if isinstance(to_dt, str) and len(to_dt) != 0:
+        to_datetime = datetime.fromisoformat(to_dt)
+    elif isinstance(to_dt, datetime):
+        to_datetime = to_dt
+    else:
+        to_datetime = datetime.utcnow()
+
     # Create flow
     with Flow("CDP Event Gather Pipeline") as flow:
-        log.info("Gathering events to process.")
-        events: List[EventIngestionModel] = get_events_func()
+        log.info(
+            f"Gathering events to process. "
+            f"({from_datetime.isoformat()} - {to_datetime.isoformat()})"
+        )
+        events: List[EventIngestionModel] = get_events_func(
+            from_dt=from_datetime,
+            to_dt=to_datetime,
+        )
+        # Safety measure catch
+        if events is None:
+            events = []
         log.info(f"Processing {len(events)} events.")
 
         for event in events:

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -84,7 +84,9 @@ def create_event_gather_flow(
     elif isinstance(from_dt, datetime):
         from_datetime = from_dt
     else:
-        from_datetime = datetime.utcnow() - timedelta(days=2)
+        from_datetime = datetime.utcnow() - timedelta(
+            days=config.default_event_gather_from_days_timedelta,
+        )
 
     # Handle to datetime
     if isinstance(to_dt, str) and len(to_dt) != 0:

--- a/cdp_backend/pipeline/mock_get_events.py
+++ b/cdp_backend/pipeline/mock_get_events.py
@@ -4,7 +4,7 @@
 import random
 from bisect import bisect_left
 from datetime import datetime, timedelta
-from typing import List
+from typing import Any, List
 
 from ..database.constants import (
     EventMinutesItemDecision,
@@ -222,7 +222,7 @@ def _get_example_event() -> EventIngestionModel:
     )
 
 
-def get_events(**kwargs) -> List[EventIngestionModel]:
+def get_events(**kwargs: Any) -> List[EventIngestionModel]:
     """
     A mock get_events function that will generate entirely random events
     based off a set of permutation settings.
@@ -242,7 +242,7 @@ RANDOM_FLOW_CONFIG = EventGatherPipelineConfig(
 RANDOM_FLOW_CONFIG._validated_gcs_bucket_name = ""
 
 
-def min_get_events(**kwargs) -> List[EventIngestionModel]:
+def min_get_events(**kwargs: Any) -> List[EventIngestionModel]:
     event = EXAMPLE_MINIMAL_EVENT
     event.sessions[0].session_datetime = datetime(2019, 4, 13)
     return [event]
@@ -256,7 +256,7 @@ MINIMAL_FLOW_CONFIG = EventGatherPipelineConfig(
 MINIMAL_FLOW_CONFIG._validated_gcs_bucket_name = ""
 
 
-def filled_get_events(**kwargs) -> List[EventIngestionModel]:
+def filled_get_events(**kwargs: Any) -> List[EventIngestionModel]:
     event = EXAMPLE_FILLED_EVENT
     return [event]
 
@@ -269,7 +269,7 @@ FILLED_FLOW_CONFIG = EventGatherPipelineConfig(
 FILLED_FLOW_CONFIG._validated_gcs_bucket_name = ""
 
 
-def many_get_events(**kwargs) -> List[EventIngestionModel]:
+def many_get_events(**kwargs: Any) -> List[EventIngestionModel]:
     event = EXAMPLE_MINIMAL_EVENT
     return [event] * 4
 

--- a/cdp_backend/pipeline/mock_get_events.py
+++ b/cdp_backend/pipeline/mock_get_events.py
@@ -222,7 +222,7 @@ def _get_example_event() -> EventIngestionModel:
     )
 
 
-def get_events() -> List[EventIngestionModel]:
+def get_events(**kwargs) -> List[EventIngestionModel]:
     """
     A mock get_events function that will generate entirely random events
     based off a set of permutation settings.
@@ -242,7 +242,7 @@ RANDOM_FLOW_CONFIG = EventGatherPipelineConfig(
 RANDOM_FLOW_CONFIG._validated_gcs_bucket_name = ""
 
 
-def min_get_events() -> List[EventIngestionModel]:
+def min_get_events(**kwargs) -> List[EventIngestionModel]:
     event = EXAMPLE_MINIMAL_EVENT
     event.sessions[0].session_datetime = datetime(2019, 4, 13)
     return [event]
@@ -256,7 +256,7 @@ MINIMAL_FLOW_CONFIG = EventGatherPipelineConfig(
 MINIMAL_FLOW_CONFIG._validated_gcs_bucket_name = ""
 
 
-def filled_get_events() -> List[EventIngestionModel]:
+def filled_get_events(**kwargs) -> List[EventIngestionModel]:
     event = EXAMPLE_FILLED_EVENT
     return [event]
 
@@ -269,7 +269,7 @@ FILLED_FLOW_CONFIG = EventGatherPipelineConfig(
 FILLED_FLOW_CONFIG._validated_gcs_bucket_name = ""
 
 
-def many_get_events() -> List[EventIngestionModel]:
+def many_get_events(**kwargs) -> List[EventIngestionModel]:
     event = EXAMPLE_MINIMAL_EVENT
     return [event] * 4
 

--- a/cdp_backend/pipeline/pipeline_config.py
+++ b/cdp_backend/pipeline/pipeline_config.py
@@ -31,6 +31,10 @@ class EventGatherPipelineConfig:
         Passthrough to sr_models.webvtt_sr_model.WebVTTSRModel.
     caption_confidence: Optional[float]
         Passthrough to sr_models.webvtt_sr_model.WebVTTSRModel.
+    default_event_gather_from_days_timedelta: int
+        Default number of days to subtract from current time to then pass to the
+        provided get_events function as the `from_dt` datetime.
+        Default: 2 (from_dt will be set to current datetime - 2 days)
     """
 
     google_credentials_file: str
@@ -43,6 +47,7 @@ class EventGatherPipelineConfig:
     )
     caption_new_speaker_turn_pattern: Optional[str] = None
     caption_confidence: Optional[float] = None
+    default_event_gather_from_days_timedelta: int = 2
 
     @property
     def validated_gcs_bucket_name(self) -> str:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

### Description of Changes

_Include a description of the proposed changes._

Working on cookiecutter / integration, I rememberd that GitHub Actions has an event called [Workflow Dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) which allows for running pipelines manually through the GitHub UI: [Docs](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) and figured that it would be a great way to allow for backfilling data on the github action runner instead of a persons local machine.

So this adds the `from` and `to` arguments to the bin script and the `from_dt` and `to_dt` arguments to the pipeline constructor itself and passes the values down to the `get_events` function that was loaded. Minor change to `get_events` spec but I think a worthwhile one.
