### PR TITLE
bugfix/remove-datetime-weighted-value-from-index-tests

### DIFF
--- a/cdp_backend/tests/pipeline/test_event_index_pipeline.py
+++ b/cdp_backend/tests/pipeline/test_event_index_pipeline.py
@@ -277,9 +277,20 @@ def test_mocked_pipeline_run(
     result_values = result_values.sort_values(by="stemmed_gram").reset_index(drop=True)
 
     # Drop certain columns that change based off datetime of test run
-    expected_values = expected_values.drop(columns=["event_id", "event_datetime"])
-    result_values = result_values.drop(columns=["event_id", "event_datetime"])
-
+    expected_values = expected_values.drop(
+        columns=[
+            "event_id",
+            "event_datetime",
+            "datetime_weighted_tfidf",
+        ]
+    )
+    result_values = result_values.drop(
+        columns=[
+            "event_id",
+            "event_datetime",
+            "datetime_weighted_tfidf",
+        ]
+    )
     pd._testing.assert_frame_equal(result_values, expected_values)
 
     # Cleanup


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

### Description of Changes

_Include a description of the proposed changes._

Build failed this morning because the checks against the index pipeline were trying to check against a datetime weighted score but for obvious reasons the datetimes have moved / change everytime the pipeline runs. So removing that column from checking.
