### PR TITLE
feature/transcript-annotation-cleanup-and-section-annotation-type

### DIFF
--- a/cdp_backend/pipeline/transcript_model.py
+++ b/cdp_backend/pipeline/transcript_model.py
@@ -57,8 +57,8 @@ class SectionAnnotation:
     Notes
     -----
     The attributes `start_sentence_index` and `stop_sentence_index` should be treated
-    as inclusive and exclusive respectively, exactly like how Python `slice` function
-    works.
+    as inclusive and exclusive respectively, exactly like how the Python `slice`
+    function works.
 
     I.e. given a transcript with ordered sentences, the sentence indices can work
     as the parameters for a slice operation:

--- a/cdp_backend/pipeline/transcript_model.py
+++ b/cdp_backend/pipeline/transcript_model.py
@@ -139,9 +139,52 @@ class Transcript:
 # Docstrings for constants go _after_ the constant.
 
 
+@dataclass_json
+@dataclass
+class SectionAnnotation:
+    """
+    A section annotation used for discourse segmentation.
+
+    Examples
+    --------
+    Usage pattern for annotation attachment.
+
+    >>> transcript.annotations[TranscriptAnnotations.sections.name] = [
+    ...     SectionAnnotation(
+    ...         name="Public Comment",
+    ...         start_sentence_index=12,
+    ...         end_sentence_index=87,
+    ...         generator="Jackson Maxfield Brown",
+    ...     ),
+    ...     SectionAnnotation(
+    ...         name="CB 120121",
+    ...         start_sentence_index=243,
+    ...         end_sentence_index=419,
+    ...         description="AN ORDINANCE relating to land use and zoning ...",
+    ...         generator="seeded-semantic-alignment--v1.0.0",
+    ...     ),
+    ... ]
+    """
+
+    name: str
+    start_sentence_index: int
+    end_sentence_index: int
+    generator: str
+    description: Optional[str] = None
+
+
 class TranscriptAnnotations(Enum):
     """
     Annotations that can appear (but are not guaranteed) for the whole transcript.
+    """
+
+    sections = List[SectionAnnotation]
+    """
+    A list of SectionAnnotations used for discourse segmentation.
+
+    See Also
+    --------
+    cdp_backend.pipeline.transcript_model.SectionAnnotation
     """
 
 

--- a/cdp_backend/pipeline/transcript_model.py
+++ b/cdp_backend/pipeline/transcript_model.py
@@ -60,8 +60,8 @@ class SectionAnnotation:
     as inclusive and exclusive respectively, exactly like how the Python `slice`
     function works.
 
-    I.e. given a transcript with ordered sentences, the sentence indices can work
-    as the parameters for a slice operation:
+    I.e. given a transcript of ordered sentences, the sentence indices will work
+    as the parameters for a slice against the list of sentences:
     `sentences[start_sentence_index:stop_sentence_index]`
 
     Examples
@@ -100,13 +100,6 @@ class TranscriptAnnotations:
     """
 
     sections: Optional[List[SectionAnnotation]] = None
-    """
-    A list of SectionAnnotations used for segmentation of the topics / sections.
-
-    See Also
-    --------
-    cdp_backend.pipeline.transcript_model.SectionAnnotation
-    """
 
 
 ###############################################################################

--- a/cdp_backend/sr_models/google_cloud_sr_model.py
+++ b/cdp_backend/sr_models/google_cloud_sr_model.py
@@ -164,8 +164,6 @@ class GoogleCloudSRModel(SRModel):
                             start_time=start_time,
                             end_time=end_time,
                             text=self._clean_word(word.word),
-                            # TODO: Add annotations
-                            annotations=None,
                         )
 
                         timestamped_sentence.words.append(timestamped_word)
@@ -197,7 +195,6 @@ class GoogleCloudSRModel(SRModel):
             session_datetime=None,
             created_datetime=datetime.utcnow().isoformat(),
             sentences=timestamped_sentences,
-            annotations=None,
         )
 
         return transcript

--- a/cdp_backend/sr_models/webvtt_sr_model.py
+++ b/cdp_backend/sr_models/webvtt_sr_model.py
@@ -139,7 +139,6 @@ class WebVTTSRModel(SRModel):
                         + (((word_index + 1) / len(raw_words)) * caption_duration)
                     ),
                     text=WebVTTSRModel._clean_word(word),
-                    annotations=None,
                 )
             )
 
@@ -249,7 +248,6 @@ class WebVTTSRModel(SRModel):
             session_datetime=None,
             created_datetime=datetime.utcnow().isoformat(),
             sentences=sentences,
-            annotations=None,
         )
         log.info(f"Completed WebVTT transcript conversion for: {file_uri}")
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

_Include a description of the proposed changes._

I got to spend some time on a couple of train rides starting to work on the section annotation problem. https://github.com/CouncilDataProject/cdp-roadmap/issues/9

Along the way, I figured I should clean up and better define our annotation problem. This is my v1 stab at it and it has worked so far. I generally like the API.

```python
transcript.annotations = TranscriptAnnotations(sections=[SectionAnnotation(), ]
```

For when there are no prior annotations and simple property setting when some annotations exist:

```python
transcript.annotations.sections = []
# OR
transcript.annotations.sections.append(SectionAnnotation())
```