### PR TITLE
bugfix/use-correct-number-of-gram-sizes-in-search-cdp-events

### DIFF
--- a/cdp_backend/bin/search_cdp_events.py
+++ b/cdp_backend/bin/search_cdp_events.py
@@ -99,7 +99,7 @@ def get_stemmed_grams_from_query(query: str) -> List[str]:
     # Create stemmed grams for query
     query_terms = clean_text(query, clean_stop_words=True).split()
     stemmed_grams = []
-    for n_gram_size in range(1, 3):
+    for n_gram_size in [1, 2, 3]:
         grams = ngrams(query_terms, n_gram_size)
         for gram in grams:
             stemmed_grams.append(" ".join(stemmer.stem(term.lower()) for term in gram))


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

_Include a description of the proposed changes._

Found while working on search cdp events in JS, this was only creating ngrams of 1 and 2 because range is exclusive to upper bound. Replaced with array of specific values for clarity and fix.
