### PR TITLE
feature/resources-exists-from-gcs-storage

### DIFF
--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -174,8 +174,14 @@ def create_event(
     agenda_uri: Optional[str] = None,
     minutes_uri: Optional[str] = None,
     external_source_id: Optional[str] = None,
+    credentials_file: Optional[str] = None,
 ) -> db_models.Event:
     db_event = db_models.Event()
+
+    if credentials_file:
+        db_event.set_validator_kwargs(
+            kwargs={"google_credentials_file": credentials_file}
+        ) 
 
     # Required fields
     db_event.body_ref = body_ref
@@ -192,9 +198,16 @@ def create_event(
 
 
 def create_session(
-    session: ingestion_models.Session, event_ref: db_models.Event
+    session: ingestion_models.Session, 
+    event_ref: db_models.Event,
+    credentials_file: Optional[str] = None,
 ) -> db_models.Session:
     db_session = db_models.Session()
+
+    if credentials_file:
+        db_session.set_validator_kwargs(
+            kwargs={"google_credentials_file": credentials_file}
+        ) 
 
     # Required fields
     db_session.event_ref = event_ref
@@ -211,10 +224,18 @@ def create_session(
     return db_session
 
 
-def create_file(uri: str) -> db_models.File:
+def create_file(
+    uri: str,
+    credentials_file: Optional[str] = None,
+) -> db_models.File:
     db_file = db_models.File()
     db_file.name = uri.split("/")[-1]
     db_file.uri = uri
+
+    if credentials_file:
+        db_file.set_validator_kwargs(
+            kwargs={"google_credentials_file": credentials_file}
+        ) 
 
     return db_file
 
@@ -268,8 +289,14 @@ def create_matter_status(
 def create_matter_file(
     matter_ref: db_models.Matter,
     supporting_file: ingestion_models.SupportingFile,
+    credentials_file: Optional[str] = None,
 ) -> db_models.MatterFile:
     db_matter_file = db_models.MatterFile()
+
+    if credentials_file:
+        db_matter_file.set_validator_kwargs(
+            kwargs={"google_credentials_file": credentials_file}
+        ) 
 
     db_matter_file.matter_ref = matter_ref
     db_matter_file.name = _strip_field(supporting_file.name)
@@ -314,9 +341,15 @@ def create_matter_sponsor(
 def create_person(
     person: ingestion_models.Person,
     picture_ref: Optional[db_models.File] = None,
+    credentials_file: Optional[str] = None,
 ) -> db_models.Person:
     # Get minimal
     db_person = create_minimal_person(person=person)
+
+    if credentials_file:
+        db_person.set_validator_kwargs(
+            kwargs={"google_credentials_file": credentials_file}
+        ) 
 
     # Optional
     db_person.router_string = _strip_field(person.router_string)
@@ -417,8 +450,14 @@ def create_event_minutes_item(
 def create_event_minutes_item_file(
     event_minutes_item_ref: db_models.EventMinutesItem,
     supporting_file: ingestion_models.SupportingFile,
+    credentials_file: Optional[str] = None,
 ) -> db_models.EventMinutesItemFile:
     db_event_minutes_item_file = db_models.EventMinutesItemFile()
+
+    if credentials_file:
+        db_event_minutes_item_file.set_validator_kwargs(
+            kwargs={"google_credentials_file": credentials_file}
+        ) 
 
     db_event_minutes_item_file.event_minutes_item_ref = event_minutes_item_ref
     db_event_minutes_item_file.name = _strip_field(supporting_file.name)

--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -181,7 +181,7 @@ def create_event(
     if credentials_file:
         db_event.set_validator_kwargs(
             kwargs={"google_credentials_file": credentials_file}
-        ) 
+        )
 
     # Required fields
     db_event.body_ref = body_ref
@@ -198,7 +198,7 @@ def create_event(
 
 
 def create_session(
-    session: ingestion_models.Session, 
+    session: ingestion_models.Session,
     event_ref: db_models.Event,
     credentials_file: Optional[str] = None,
 ) -> db_models.Session:
@@ -207,7 +207,7 @@ def create_session(
     if credentials_file:
         db_session.set_validator_kwargs(
             kwargs={"google_credentials_file": credentials_file}
-        ) 
+        )
 
     # Required fields
     db_session.event_ref = event_ref
@@ -235,7 +235,7 @@ def create_file(
     if credentials_file:
         db_file.set_validator_kwargs(
             kwargs={"google_credentials_file": credentials_file}
-        ) 
+        )
 
     return db_file
 
@@ -296,7 +296,7 @@ def create_matter_file(
     if credentials_file:
         db_matter_file.set_validator_kwargs(
             kwargs={"google_credentials_file": credentials_file}
-        ) 
+        )
 
     db_matter_file.matter_ref = matter_ref
     db_matter_file.name = _strip_field(supporting_file.name)
@@ -349,7 +349,7 @@ def create_person(
     if credentials_file:
         db_person.set_validator_kwargs(
             kwargs={"google_credentials_file": credentials_file}
-        ) 
+        )
 
     # Optional
     db_person.router_string = _strip_field(person.router_string)
@@ -457,7 +457,7 @@ def create_event_minutes_item_file(
     if credentials_file:
         db_event_minutes_item_file.set_validator_kwargs(
             kwargs={"google_credentials_file": credentials_file}
-        ) 
+        )
 
     db_event_minutes_item_file.event_minutes_item_ref = event_minutes_item_ref
     db_event_minutes_item_file.name = _strip_field(supporting_file.name)

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -35,6 +35,15 @@ class File(Model):
     class Meta:
         ignore_none_field = False
 
+    def set_validator_kwargs(self, kwargs: Dict) -> None:
+        field = fields.TextField(
+            required=True, 
+            validator=validators.resource_exists,
+            validator_kwargs=kwargs
+        )
+
+        field.contribute_to_model(File, "uri")
+
     @classmethod
     def Example(cls) -> Model:
         uri = "gs://cdp-example/central-staff-memo.pdf"
@@ -68,6 +77,14 @@ class Person(Model):
 
     class Meta:
         ignore_none_field = False
+
+    def set_validator_kwargs(self, kwargs: Dict) -> None:
+        field = fields.TextField(
+            validator=validators.resource_exists,
+            validator_kwargs=kwargs,
+        )
+
+        field.contribute_to_model(Person, "website")
 
     @classmethod
     def Example(cls) -> Model:
@@ -250,6 +267,15 @@ class MatterFile(Model):
     class Meta:
         ignore_none_field = False
 
+    def set_validator_kwargs(self, kwargs: Dict) -> None:
+        field = fields.TextField(
+            required=True, 
+            validator=validators.resource_exists,
+            validator_kwargs=kwargs
+        )
+
+        field.contribute_to_model(MatterFile, "uri")
+
     @classmethod
     def Example(cls) -> Model:
         matter_file = cls()
@@ -342,6 +368,15 @@ class Event(Model):
     class Meta:
         ignore_none_field = False
 
+    def set_validator_kwargs(self, kwargs: Dict) -> None:
+        field = fields.TextField(
+            validator=validators.resource_exists,
+            validator_kwargs=kwargs
+        )
+
+        field.contribute_to_model(Event, "agenda_uri")
+        field.contribute_to_model(Event, "minutes_uri")
+
     @classmethod
     def Example(cls) -> Model:
         event = cls()
@@ -390,6 +425,15 @@ class Session(Model):
 
     class Meta:
         ignore_none_field = False
+
+    def set_validator_kwargs(self, kwargs: Dict) -> None:
+        field = fields.TextField(
+            required=True, 
+            validator=validators.resource_exists,
+            validator_kwargs=kwargs
+        )
+
+        field.contribute_to_model(Session, "video_uri")
 
     @classmethod
     def Example(cls) -> Model:
@@ -557,6 +601,15 @@ class EventMinutesItemFile(Model):
 
     class Meta:
         ignore_none_field = False
+
+    def set_validator_kwargs(self, kwargs: Dict) -> None:
+        field = fields.TextField(
+            required=True, 
+            validator=validators.resource_exists,
+            validator_kwargs=kwargs
+        )
+
+        field.contribute_to_model(EventMinutesItemFile, "uri")
 
     @classmethod
     def Example(cls) -> Model:

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -4,6 +4,7 @@
 import re
 import unicodedata
 from datetime import datetime
+from typing import Dict
 
 from fireo import fields
 from fireo.models import Model
@@ -17,7 +18,6 @@ from .constants import (
     VoteDecision,
 )
 from .types import IndexedField, IndexedFieldSet
-from typing import Dict
 
 ###############################################################################
 
@@ -38,9 +38,7 @@ class File(Model):
 
     def set_validator_kwargs(self, kwargs: Dict) -> None:
         field = fields.TextField(
-            required=True, 
-            validator=validators.resource_exists,
-            validator_kwargs=kwargs
+            required=True, validator=validators.resource_exists, validator_kwargs=kwargs
         )
 
         field.contribute_to_model(File, "uri")
@@ -270,9 +268,7 @@ class MatterFile(Model):
 
     def set_validator_kwargs(self, kwargs: Dict) -> None:
         field = fields.TextField(
-            required=True, 
-            validator=validators.resource_exists,
-            validator_kwargs=kwargs
+            required=True, validator=validators.resource_exists, validator_kwargs=kwargs
         )
 
         field.contribute_to_model(MatterFile, "uri")
@@ -371,8 +367,7 @@ class Event(Model):
 
     def set_validator_kwargs(self, kwargs: Dict) -> None:
         field = fields.TextField(
-            validator=validators.resource_exists,
-            validator_kwargs=kwargs
+            validator=validators.resource_exists, validator_kwargs=kwargs
         )
 
         field.contribute_to_model(Event, "agenda_uri")
@@ -429,9 +424,7 @@ class Session(Model):
 
     def set_validator_kwargs(self, kwargs: Dict) -> None:
         field = fields.TextField(
-            required=True, 
-            validator=validators.resource_exists,
-            validator_kwargs=kwargs
+            required=True, validator=validators.resource_exists, validator_kwargs=kwargs
         )
 
         field.contribute_to_model(Session, "video_uri")
@@ -605,9 +598,7 @@ class EventMinutesItemFile(Model):
 
     def set_validator_kwargs(self, kwargs: Dict) -> None:
         field = fields.TextField(
-            required=True, 
-            validator=validators.resource_exists,
-            validator_kwargs=kwargs
+            required=True, validator=validators.resource_exists, validator_kwargs=kwargs
         )
 
         field.contribute_to_model(EventMinutesItemFile, "uri")

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -17,6 +17,7 @@ from .constants import (
     VoteDecision,
 )
 from .types import IndexedField, IndexedFieldSet
+from typing import Dict
 
 ###############################################################################
 

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -124,6 +124,9 @@ def resource_exists(uri: Optional[str], **kwargs) -> bool:
                 uri = convert_gcs_json_url_to_gsutil_form(uri)
 
                 # If uri is not convertible to gsutil form we can't confirm
+                print("URI")
+                print(uri)
+                print("EXISTS? " + str(fs.exists(uri)))
                 if uri == "":
                     return True
 

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -115,7 +115,7 @@ def resource_exists(uri: Optional[str], **kwargs) -> bool:
         if kwargs.get("google_credentials_file"):
             fs = GCSFileSystem(token=str(kwargs.get("google_credentials_file")))
 
-            gcs_uri = 
+            #gcs_uri = 
 
 
     if uri is None:

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -94,7 +94,7 @@ def email_is_valid(email: Optional[str]) -> bool:
     return False
 
 
-def resource_exists(uri: Optional[str]) -> bool:
+def resource_exists(uri: Optional[str], **kwargs) -> bool:
     """
     Validate that the URI provided points to an existing file.
 
@@ -110,6 +110,13 @@ def resource_exists(uri: Optional[str]) -> bool:
     status: bool
         The validation status.
     """
+
+    if uri.startswith("gs://") or uri.startswith("https://storage.googleapis"):
+        if kwargs.get("google_credentials_file"):
+            fs = GCSFileSystem(token=str(kwargs.get("google_credentials_file")))
+
+            gcs_uri = 
+
 
     if uri is None:
         return True

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -8,6 +8,7 @@ from typing import Callable, List, Optional, Type
 
 from fireo.models import Model
 from fsspec.core import url_to_fs
+from gcsfs import GCSFileSystem
 
 from ..utils.constants_utils import get_all_class_attr_values
 from ..utils.string_utils import convert_gcs_json_url_to_gsutil_form
@@ -124,9 +125,6 @@ def resource_exists(uri: Optional[str], **kwargs) -> bool:
                 uri = convert_gcs_json_url_to_gsutil_form(uri)
 
                 # If uri is not convertible to gsutil form we can't confirm
-                print("URI")
-                print(uri)
-                print("EXISTS? " + str(fs.exists(uri)))
                 if uri == "":
                     return True
 

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -96,7 +96,7 @@ def email_is_valid(email: Optional[str]) -> bool:
     return False
 
 
-def resource_exists(uri: Optional[str], **kwargs) -> bool:
+def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
     """
     Validate that the URI provided points to an existing file.
 

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -120,12 +120,6 @@ def create_event_gather_flow(
             events = []
         log.info(f"Processing {len(events)} events.")
 
-
-        print("CONFIG")
-        fs = GCSFileSystem(token=str(config.google_credentials_file))
-        #print(fs.exists("https://storage.googleapis.com/download/storage/v1/b/stg-cdp-seattle-isaac.appspot.com/o/roe-jogan.mp4?alt=media"))
-        print(fs.exists("gs://stg-cdp-seattle-isaac.appspot.com/roe-jogan.mp4"))
-
         for event in events:
             session_processing_results: List[SessionProcessingResult] = []
             for session in event.sessions:
@@ -826,7 +820,10 @@ def _process_person_ingestion(
                 filepath=tmp_person_picture_path,
             )
             fs_functions.remove_local_file(tmp_person_picture_path)
-            person_picture_db_model = db_functions.create_file(person_picture_uri)
+            person_picture_db_model = db_functions.create_file(
+                uri=person_picture_uri, 
+                credentials_file=credentials_file,
+            )
             person_picture_db_model = db_functions.upload_db_model(
                 db_model=person_picture_db_model,
                 credentials_file=credentials_file,
@@ -842,6 +839,7 @@ def _process_person_ingestion(
         person_db_model = db_functions.create_person(
             person=person,
             picture_ref=person_picture_db_model,
+            credentials_file=credentials_file,
         )
         person_db_model = db_functions.upload_db_model(
             db_model=person_db_model,
@@ -874,7 +872,8 @@ def _process_person_ingestion(
                     tmp_person_seat_image_path,
                 )
                 person_seat_image_db_model = db_functions.create_file(
-                    person_seat_image_uri
+                    uri=person_seat_image_uri,
+                    credentials_file=credentials_file
                 )
                 person_seat_image_db_model = db_functions.upload_db_model(
                     db_model=person_seat_image_db_model,
@@ -1009,6 +1008,7 @@ def store_event_processing_results(
         # Upload static thumbnail
         static_thumbnail_file_db_model = db_functions.create_file(
             uri=session_result.static_thumbnail_uri,
+            credentials_file=credentials_file,
         )
         static_thumbnail_file_db_model = db_functions.upload_db_model(
             db_model=static_thumbnail_file_db_model,
@@ -1020,6 +1020,7 @@ def store_event_processing_results(
         # Upload hover thumbnail
         hover_thumbnail_file_db_model = db_functions.create_file(
             uri=session_result.hover_thumbnail_uri,
+            credentials_file=credentials_file,
         )
         hover_thumbnail_file_db_model = db_functions.upload_db_model(
             db_model=hover_thumbnail_file_db_model,
@@ -1038,6 +1039,7 @@ def store_event_processing_results(
             agenda_uri=event.agenda_uri,
             minutes_uri=event.minutes_uri,
             external_source_id=event.external_source_id,
+            credentials_file=credentials_file,
         )
         event_db_model = db_functions.upload_db_model(
             db_model=event_db_model,
@@ -1050,6 +1052,7 @@ def store_event_processing_results(
             static_thumbnail_ref=event_static_thumbnail_file_db_model,
             hover_thumbnail_ref=event_hover_thumbnail_file_db_model,
             external_source_id=event.external_source_id,
+            credentials_file=credentials_file,
         )
         event_db_model = db_functions.upload_db_model(
             db_model=event_db_model,
@@ -1059,7 +1062,10 @@ def store_event_processing_results(
     # Iter sessions
     for session_result in session_processing_results:
         # Upload audio file
-        audio_file_db_model = db_functions.create_file(uri=session_result.audio_uri)
+        audio_file_db_model = db_functions.create_file(
+            uri=session_result.audio_uri,
+            credentials_file=credentials_file,
+        )
         audio_file_db_model = db_functions.upload_db_model(
             db_model=audio_file_db_model,
             credentials_file=credentials_file,
@@ -1068,6 +1074,7 @@ def store_event_processing_results(
         # Upload transcript file
         transcript_file_db_model = db_functions.create_file(
             uri=session_result.transcript_uri,
+            credentials_file=credentials_file,
         )
         transcript_file_db_model = db_functions.upload_db_model(
             db_model=transcript_file_db_model,
@@ -1084,6 +1091,7 @@ def store_event_processing_results(
         session_db_model = db_functions.create_session(
             session=session_result.session,
             event_ref=event_db_model,
+            credentials_file=credentials_file,
         )
         session_db_model = db_functions.upload_db_model(
             db_model=session_db_model,
@@ -1217,6 +1225,7 @@ def store_event_processing_results(
                             matter_file_db_model = db_functions.create_matter_file(
                                 matter_ref=matter_db_model,
                                 supporting_file=supporting_file,
+                                credentials_file=credentials_file,
                             )
                             matter_file_db_model = db_functions.upload_db_model(
                                 db_model=matter_file_db_model,
@@ -1234,6 +1243,7 @@ def store_event_processing_results(
                             db_functions.create_event_minutes_item_file(
                                 event_minutes_item_ref=event_minutes_item_db_model,
                                 supporting_file=supporting_file,
+                                credentials_file=credentials_file,
                             )
                         )
                         event_minutes_item_file_db_model = db_functions.upload_db_model(

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -821,7 +821,7 @@ def _process_person_ingestion(
             )
             fs_functions.remove_local_file(tmp_person_picture_path)
             person_picture_db_model = db_functions.create_file(
-                uri=person_picture_uri, 
+                uri=person_picture_uri,
                 credentials_file=credentials_file,
             )
             person_picture_db_model = db_functions.upload_db_model(
@@ -872,8 +872,7 @@ def _process_person_ingestion(
                     tmp_person_seat_image_path,
                 )
                 person_seat_image_db_model = db_functions.create_file(
-                    uri=person_seat_image_uri,
-                    credentials_file=credentials_file
+                    uri=person_seat_image_uri, credentials_file=credentials_file
                 )
                 person_seat_image_db_model = db_functions.upload_db_model(
                     db_model=person_seat_image_db_model,

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -120,6 +120,12 @@ def create_event_gather_flow(
             events = []
         log.info(f"Processing {len(events)} events.")
 
+
+        print("CONFIG")
+        fs = GCSFileSystem(token=str(config.google_credentials_file))
+        #print(fs.exists("https://storage.googleapis.com/download/storage/v1/b/stg-cdp-seattle-isaac.appspot.com/o/roe-jogan.mp4?alt=media"))
+        print(fs.exists("gs://stg-cdp-seattle-isaac.appspot.com/roe-jogan.mp4"))
+
         for event in events:
             session_processing_results: List[SessionProcessingResult] = []
             for session in event.sessions:

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import pytest
 from typing import Dict, Optional
 from unittest import mock
-import gcsfs
+
+import pytest
 
 from cdp_backend.database import models, validators
 from cdp_backend.database.constants import (
@@ -74,8 +74,8 @@ def test_email_is_valid(email: str, expected_result: bool) -> None:
     ],
 )
 def test_local_resource_exists(
-    uri: str, 
-    expected_result: bool, 
+    uri: str,
+    expected_result: bool,
 ) -> None:
     actual_result = validators.resource_exists(uri)
     assert actual_result == expected_result
@@ -92,14 +92,26 @@ def test_local_resource_exists(
         ("https://docs.pytest.org/en/latest/index.html", True, None, None),
         ("https://docs.pytest.org/en/latest/does-not-exist.html", False, None, None),
         ("gs://bucket/filename.txt", True, True, validator_kwargs),
-        ("https://storage.googleapis.com/download/storage/v1/b/bucket.appspot.com/o/wombo_combo.mp4?alt=media", True, True, validator_kwargs),
+        (
+            "https://storage.googleapis.com/download/storage/v1/b/"
+            + "bucket.appspot.com/o/wombo_combo.mp4?alt=media",
+            True,
+            True,
+            validator_kwargs,
+        ),
         ("gs://bucket/filename.txt", False, False, validator_kwargs),
         # Unconvertible JSON url case
-        ("https://storage.googleapis.com/download/storage/v1/xxx/bucket.appspot.com", True, None, None),
+        (
+            "https://storage.googleapis.com/download/storage/v1/xxx/"
+            + "bucket.appspot.com",
+            True,
+            None,
+            None,
+        ),
     ],
 )
 def test_remote_resource_exists(
-    uri: str, 
+    uri: str,
     expected_result: bool,
     gcsfs_exists: Optional[bool],
     kwargs: Optional[Dict],

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -2,6 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from typing import Dict, Optional
+from unittest import mock
+import gcsfs
 
 from cdp_backend.database import models, validators
 from cdp_backend.database.constants import (
@@ -14,6 +17,7 @@ from .. import test_utils
 
 #############################################################################
 
+validator_kwargs = {"google_credentials_file": "filepath"}
 
 """
 Uniqueness test constants 
@@ -69,7 +73,10 @@ def test_email_is_valid(email: str, expected_result: bool) -> None:
         ("file://does-not-exist.txt", False),
     ],
 )
-def test_local_resource_exists(uri: str, expected_result: bool) -> None:
+def test_local_resource_exists(
+    uri: str, 
+    expected_result: bool, 
+) -> None:
     actual_result = validators.resource_exists(uri)
     assert actual_result == expected_result
 
@@ -79,16 +86,33 @@ def test_local_resource_exists(uri: str, expected_result: bool) -> None:
     reason="No internet connection",
 )
 @pytest.mark.parametrize(
-    "uri, expected_result",
+    "uri, expected_result, gcsfs_exists, kwargs",
     [
-        (None, True),
-        ("https://docs.pytest.org/en/latest/index.html", True),
-        ("https://docs.pytest.org/en/latest/does-not-exist.html", False),
+        (None, True, None, None),
+        ("https://docs.pytest.org/en/latest/index.html", True, None, None),
+        ("https://docs.pytest.org/en/latest/does-not-exist.html", False, None, None),
+        ("gs://bucket/filename.txt", True, True, validator_kwargs),
+        ("https://storage.googleapis.com/download/storage/v1/b/bucket.appspot.com/o/wombo_combo.mp4?alt=media", True, True, validator_kwargs),
+        ("gs://bucket/filename.txt", False, False, validator_kwargs),
+        # Unconvertible JSON url case
+        ("https://storage.googleapis.com/download/storage/v1/xxx/bucket.appspot.com", True, None, None),
     ],
 )
-def test_remote_resource_exists(uri: str, expected_result: bool) -> None:
-    actual_result = validators.resource_exists(uri)
-    assert actual_result == expected_result
+def test_remote_resource_exists(
+    uri: str, 
+    expected_result: bool,
+    gcsfs_exists: Optional[bool],
+    kwargs: Optional[Dict],
+) -> None:
+    with mock.patch("gcsfs.credentials.GoogleCredentials.connect"):
+        with mock.patch("gcsfs.GCSFileSystem.exists") as mock_exists:
+            mock_exists.return_value = gcsfs_exists
+            if kwargs:
+                actual_result = validators.resource_exists(uri, **kwargs)
+            else:
+                actual_result = validators.resource_exists(uri)
+
+            assert actual_result == expected_result
 
 
 @pytest.mark.parametrize(

--- a/cdp_backend/tests/utils/test_string_utils.py
+++ b/cdp_backend/tests/utils/test_string_utils.py
@@ -27,3 +27,13 @@ from cdp_backend.utils import string_utils
 )
 def test_clean_text(text: str, expected: str, clean_stop_words: bool) -> None:
     assert string_utils.clean_text(text, clean_stop_words=clean_stop_words) == expected
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("https://storage.googleapis.com/download/storage/v1/b/bucket.appspot.com/o/wombo_combo.mp4?alt=media", "gs://bucket.appspot.com/wombo_combo.mp4"),
+        ("https://storage.googleapis.com/download/storage/bucket.appspot.com/o/wombo_combo.mp4?alt=media", ""),
+    ],
+)
+def test_convert_gcs_json_url_to_gsutil_form(text: str, expected: str) -> None:
+    assert string_utils.convert_gcs_json_url_to_gsutil_form(text) == expected

--- a/cdp_backend/tests/utils/test_string_utils.py
+++ b/cdp_backend/tests/utils/test_string_utils.py
@@ -28,11 +28,21 @@ from cdp_backend.utils import string_utils
 def test_clean_text(text: str, expected: str, clean_stop_words: bool) -> None:
     assert string_utils.clean_text(text, clean_stop_words=clean_stop_words) == expected
 
+
 @pytest.mark.parametrize(
     "text, expected",
     [
-        ("https://storage.googleapis.com/download/storage/v1/b/bucket.appspot.com/o/wombo_combo.mp4?alt=media", "gs://bucket.appspot.com/wombo_combo.mp4"),
-        ("https://storage.googleapis.com/download/storage/bucket.appspot.com/o/wombo_combo.mp4?alt=media", ""),
+        (
+            "https://storage.googleapis.com/download/storage/v1/b/"
+            + "bucket.appspot.com/o/wombo_combo.mp4?alt=media",
+            "gs://bucket.appspot.com/wombo_combo.mp4",
+        ),
+        # Invalid format
+        (
+            "https://storage.googleapis.com/download/storage/"
+            + "bucket.appspot.com/o/wombo_combo.mp4?alt=media",
+            "",
+        ),
     ],
 )
 def test_convert_gcs_json_url_to_gsutil_form(text: str, expected: str) -> None:

--- a/cdp_backend/utils/string_utils.py
+++ b/cdp_backend/utils/string_utils.py
@@ -80,3 +80,33 @@ def clean_text(text: str, clean_stop_words: bool = False) -> str:
         return ""
 
     return cleaned_doc
+
+
+def convert_gcs_json_url_to_gsutil_form(url: str):
+    """
+    Convert a GCS JSON API url to its corresponding gsutil uri.
+
+    Parameters
+    ----------
+    url: str
+        The url in GCS JSON API form.
+
+    Returns
+    -------
+    gsutil_url: str
+        The url in gsutil form. Returns empty string if the input url doesn't 
+        match the form.
+    """
+
+    bucket = re.search('storage.googleapis.com/download/storage/v1/b/(.+?)/o', url)
+    if bucket:
+        bucket = bucket.group(1)
+
+    filename = re.search('/o/(.+?)\?alt=media', url) 
+    if filename: 
+        filename = filename.group(1)
+
+    if bucket and filename:
+        return f"gs://{bucket}/{filename}"
+
+    return ""

--- a/cdp_backend/utils/string_utils.py
+++ b/cdp_backend/utils/string_utils.py
@@ -94,16 +94,16 @@ def convert_gcs_json_url_to_gsutil_form(url: str):
     Returns
     -------
     gsutil_url: str
-        The url in gsutil form. Returns empty string if the input url doesn't 
+        The url in gsutil form. Returns empty string if the input url doesn't
         match the form.
     """
 
-    bucket = re.search('storage.googleapis.com/download/storage/v1/b/(.+?)/o', url)
+    bucket = re.search("storage.googleapis.com/download/storage/v1/b/(.+?)/o", url)
     if bucket:
         bucket = bucket.group(1)
 
-    filename = re.search('/o/(.+?)\?alt=media', url) 
-    if filename: 
+    filename = re.search(r"/o/(.+?)\?alt=media", url)
+    if filename:
         filename = filename.group(1)
 
     if bucket and filename:

--- a/cdp_backend/utils/string_utils.py
+++ b/cdp_backend/utils/string_utils.py
@@ -82,7 +82,7 @@ def clean_text(text: str, clean_stop_words: bool = False) -> str:
     return cleaned_doc
 
 
-def convert_gcs_json_url_to_gsutil_form(url: str):
+def convert_gcs_json_url_to_gsutil_form(url: str) -> str:
     """
     Convert a GCS JSON API url to its corresponding gsutil uri.
 
@@ -98,15 +98,17 @@ def convert_gcs_json_url_to_gsutil_form(url: str):
         match the form.
     """
 
+    found_bucket, found_filename = None, None
+
     bucket = re.search("storage.googleapis.com/download/storage/v1/b/(.+?)/o", url)
     if bucket:
-        bucket = bucket.group(1)
+        found_bucket = str(bucket.group(1))
 
     filename = re.search(r"/o/(.+?)\?alt=media", url)
     if filename:
-        filename = filename.group(1)
+        found_filename = str(filename.group(1))
 
-    if bucket and filename:
-        return f"gs://{bucket}/{filename}"
+    if found_bucket and found_filename:
+        return f"gs://{found_bucket}/{found_filename}"
 
     return ""

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
-    dependency_links=['https://github.com/octabytes/FireO/tarball/master#egg=FireO'],
     description=(
         "Data storage utilities and processing pipelines to run on CDP server "
         "deployments."

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 requirements = [
     "dataclasses-json~=0.5",
-    "fireo~=1.4.5",
+    "FireO @ git+https://github.com/octabytes/FireO.git#egg=FireO",
     "fsspec",  # Version pin set by gcsfs
     "gcsfs~=2021.7.0",
 ]
@@ -98,6 +98,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
+    dependency_links=['https://github.com/octabytes/FireO/tarball/master#egg=FireO'],
     description=(
         "Data storage utilities and processing pipelines to run on CDP server "
         "deployments."

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 requirements = [
     "dataclasses-json~=0.5",
-    "fireo~=1.4",
+    "fireo~=1.4.5",
     "fsspec",  # Version pin set by gcsfs
     "gcsfs~=2021.7.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 requirements = [
     "dataclasses-json~=0.5",
-    "FireO @ git+https://github.com/octabytes/FireO.git@d6b47f8d5c62025f786559ff68b327521acb14f2#egg=FireO",
+    "fireo~=1.4.5",
     "fsspec",  # Version pin set by gcsfs
     "gcsfs~=2021.7.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dev_requirements = [
 
 requirements = [
     "dataclasses-json~=0.5",
-    "FireO @ git+https://github.com/octabytes/FireO.git#egg=FireO",
+    "FireO @ git+https://github.com/octabytes/FireO.git@d6b47f8d5c62025f786559ff68b327521acb14f2#egg=FireO",
     "fsspec",  # Version pin set by gcsfs
     "gcsfs~=2021.7.0",
 ]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #52 

### Description of Changes
- Allowing validating GCS uri's by passing in the credentials file since FireO now supports `validator_kwargs`
- Created a method to transform the GCS JSON API format to a gsutil formatted string, because that's what `GCSFileSystem` works with
- Added a dependency on FireO by installing via github, with the commit specifically for the changes when I [added the kwargs](https://github.com/isaacna/FireO/commit/d6b47f8d5c62025f786559ff68b327521acb14f2)
  - We have to do this the 1.4.5 version which contains my changes hasn't been released to PyPi yet. I already have an [issue](https://github.com/octabytes/FireO/issues/125) open for that and will change it to 1.4.5 once that happens 

### Testing
- Ran a run of the local file processing script which uses GCS uri's and verified that they are being validated properly