### PR TITLE
feature/set-default-acl-for-programmatic-public-storage-read

### DIFF
--- a/cdp_backend/infrastructure/cdp_stack.py
+++ b/cdp_backend/infrastructure/cdp_stack.py
@@ -138,6 +138,15 @@ class CDPStack(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self.firebase_init),
         )
 
+        # Set full public read on bucket
+        self.storage_public_read = gcp.storage.DefaultObjectAccessControl(
+            f"{self.gcp_project_id}-storage-acl-public-viewer",
+            bucket=self.firestore_app.default_bucket,
+            entity="allUsers",
+            role="READER",
+            opts=pulumi.ResourceOptions(parent=self.firestore_app),
+        )
+
         # Create all firestore indexes
         for model_cls in DATABASE_MODELS:
             for idx_field_set in model_cls._INDEXES:

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -28,12 +28,18 @@ init: ## See README, must provide "project"
 	echo "Follow the link to setup billing for the created GCloud account."
 	echo "https://console.cloud.google.com/billing/linkedaccount?project=${project}"
 
+set-cors: ## Set cors for the bucket, must provide "project"
+	gsutil cors set cors.json gs://${project}.appspot.com/
+
 build: ## Run pulumi up for infra setup
 	pulumi up -p 4
 
-clean: ## Remove all database documents and filestore objects, must provide "key"
-	clean_cdp_database ${key}
-	clean_cdp_filestore ${key}
+switch-project: ## Switch active gcloud project, must provide "project"
+	gcloud config set project ${project}
+
+clean: ## Remove all database documents and filestore objects
+	clean_cdp_database ../.keys/cdp-dev.json
+	clean_cdp_filestore ../.keys/cdp-dev.json
 
 reset: ## Run pulumi destroy and make build, must provide "project"
 	pulumi destroy -p 4

--- a/dev-infrastructure/cors.json
+++ b/dev-infrastructure/cors.json
@@ -1,0 +1,7 @@
+[
+    {
+        "origin": ["*"],
+        "method": ["GET"],
+        "maxAgeSeconds": 3600
+    }
+]

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,12 @@ setup_requirements = [
     "pytest-runner>=5.2",
 ]
 
+infrastructure_requirements = [
+    "pulumi~=3.3",
+    "pulumi-google-native~=0.7.0",
+    "pulumi-gcp~=5.7",
+]
+
 pipeline_requirements = [
     "dask[distributed]>=2021.7.0",
     "ffmpeg-python~=0.2.0",
@@ -22,9 +28,6 @@ pipeline_requirements = [
     "nltk~=3.6",
     "pandas~=1.2",
     "prefect~=0.14.0",
-    "pulumi~=3.3",
-    "pulumi-google-native~=0.7.0",
-    "pulumi-gcp~=5.7",
     "rapidfuzz~=1.4",
     "spacy~=3.0",
     "truecase~=0.0.12",
@@ -32,6 +35,7 @@ pipeline_requirements = [
 ]
 
 test_requirements = [
+    *infrastructure_requirements,
     *pipeline_requirements,
     "black>=19.10b0",
     "codecov==2.1.12",
@@ -77,6 +81,7 @@ requirements = [
 
 extra_requirements = {
     "setup": setup_requirements,
+    "infrastructure": infrastructure_requirements,
     "pipeline": pipeline_requirements,
     "test": test_requirements,
     "dev": dev_requirements,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

Resolves #103 
Partial #14 

### Description of Changes

_Include a description of the proposed changes._

Splits up infrastructure deps and adds a default object access control policy to the storage bucket that allows for programmatic anon read of the bucket object. This isn't full public read because the front-end API still needs the security rules to be updated as well but for things like `fsspec` this is enough.

Will need to update all objects in the test-deployment bucket ACLs