### PR TITLE
Only use temp directory if dst not defined

### DIFF
--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -84,9 +84,9 @@ def resource_copy(
     if dst is None:
         dst = uri.split("/")[-1]
 
-    # Create tmp directory to save file in
-    dirpath = tempfile.mkdtemp()
-    dst = Path(dirpath) / dst
+        # Create tmp directory to save file in
+        dirpath = tempfile.mkdtemp()
+        dst = Path(dirpath) / dst
 
     # Ensure dst doesn't exist
     dst = Path(dst).resolve()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->


### Description of Changes

- Fixing a bug where we were creating a temporary directory everytime in `resource_copy` [here](https://github.com/CouncilDataProject/cdp-backend/blob/main/cdp_backend/utils/file_utils.py#L84-L89) instead of directly using `dst` when provided
- Now we only create the temp directory if `dst` is not defined to avoid resource copying directly into `cdp_backend`. [Context](https://github.com/CouncilDataProject/cdp-backend/pull/89#discussion_r691814155) for why this matters