### PR TITLE
feature/add-generator-to-db-transcript-model

### DIFF
--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -254,6 +254,7 @@ def create_transcript(
 
     db_transcript.session_ref = session_ref
     db_transcript.file_ref = transcript_file_ref
+    db_transcript.generator = transcript.generator
     db_transcript.confidence = transcript.confidence
     db_transcript.created = datetime.fromisoformat(transcript.created_datetime)
 

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -458,6 +458,7 @@ class Transcript(Model):
     id = fields.IDField()
     session_ref = fields.ReferenceField(Session, required=True, auto_load=False)
     file_ref = fields.ReferenceField(File, required=True, auto_load=False)
+    generator = fields.TextField(required=True)
     confidence = fields.NumberField(required=True)
     created = fields.DateTime(required=True)
 

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -470,6 +470,7 @@ class Transcript(Model):
         transcript = cls()
         transcript.session_ref = Session.Example()
         transcript.file_ref = File.Example()
+        transcript.generator = "FakeGen -- v0.1.0"
         transcript.confidence = 0.943
         transcript.created = datetime.utcnow()
         return transcript

--- a/cdp_backend/pipeline/transcript_model.py
+++ b/cdp_backend/pipeline/transcript_model.py
@@ -177,15 +177,15 @@ class Transcript:
 
     Parameters
     ----------
+    generator: str
+        A descriptive name of the generative process that produced this transcript.
+        Example: "Google Speech-to-Text -- Lib Version: 2.0.1"
     confidence: float
         A number between 0 and 1.
         If available, use the average of all confidence annotations reported for each
         text block in the transcript.
         Otherwise, make an estimation for (or manually calculate):
         `n-correct-tokens / n-total-tokens` for the whole transcript.
-    generator: str
-        A descriptive name of the generative process that produced this transcript.
-        Example: "Google Speech-to-Text -- Lib Version: 2.0.1"
     session_datetime: Optional[str]
         ISO formatted datetime for the session that this document transcribes.
     created_datetime: str
@@ -210,8 +210,8 @@ class Transcript:
     ...     transcript = Transcript.from_json(open_resource.read())
     """
 
-    confidence: float
     generator: str
+    confidence: float
     session_datetime: Optional[str]
     created_datetime: str
     sentences: List[Sentence]
@@ -222,8 +222,8 @@ class Transcript:
 
 
 EXAMPLE_TRANSCRIPT = Transcript(
-    confidence=0.93325,
     generator="JacksonGen -- Lib Version: 0.0.0",
+    confidence=0.93325,
     session_datetime=datetime(2021, 1, 10, 15).isoformat(),
     created_datetime=datetime.utcnow().isoformat(),
     sentences=[

--- a/cdp_backend/sr_models/google_cloud_sr_model.py
+++ b/cdp_backend/sr_models/google_cloud_sr_model.py
@@ -190,8 +190,8 @@ class GoogleCloudSRModel(SRModel):
 
         # Create transcript model
         transcript = transcript_model.Transcript(
-            confidence=confidence,
             generator=f"Google Speech-to-Text -- CDP v{__version__}",
+            confidence=confidence,
             session_datetime=None,
             created_datetime=datetime.utcnow().isoformat(),
             sentences=timestamped_sentences,

--- a/cdp_backend/sr_models/sr_model.py
+++ b/cdp_backend/sr_models/sr_model.py
@@ -3,7 +3,6 @@
 
 import re
 from abc import ABC, abstractmethod
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Union
 
@@ -30,14 +29,6 @@ class SRModel(ABC):
         outputs: transcript_model.Transcript
             The transcript model for the supplied media file.
         """
-
-        return transcript_model.Transcript(
-            0.0,
-            "",
-            "",
-            datetime.utcnow().isoformat(),
-            [],
-        )
 
     @staticmethod
     def _clean_word(word: str) -> str:

--- a/cdp_backend/sr_models/webvtt_sr_model.py
+++ b/cdp_backend/sr_models/webvtt_sr_model.py
@@ -243,8 +243,8 @@ class WebVTTSRModel(SRModel):
             sentence.text = self._normalize_text(sentence.text)
 
         transcript = transcript_model.Transcript(
-            confidence=(sum([s.confidence for s in sentences]) / len(sentences)),
             generator=f"CDP WebVTT Conversion -- CDP v{__version__}",
+            confidence=(sum([s.confidence for s in sentences]) / len(sentences)),
             session_datetime=None,
             created_datetime=datetime.utcnow().isoformat(),
             sentences=sentences,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

_Include a description of the proposed changes._

Adds the "generator" field to the database transcript model. I have wanted to add this for a while because I know I will want to be able to query for transcripts based off generator version. I.e. transcripts.generator == "Google Speech-to-Text -- CDP v3.0.0.dev19"

Additionally I am simply swapping the order of the Transcript JSON model params. It makes more sense to say:
"A transcript was created using this generator and produced this confidence" imo. It's super nitpicky but that is API design for ya.

---

Interestingly I have no idea how existing infrastructures will react to a schema change like this so it's nice to be able to test this now while we have test-deployment running before trying to do stuff like this in the future.