### PR TITLE
debug/error-logging-for-field-validation-failed

### DIFF
--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -1361,7 +1361,11 @@ def store_event_processing_results(
                                 db_model=vote_db_model,
                                 credentials_file=credentials_file,
                             )
-                        except (FieldValidationFailed, RequiredField, InvalidFieldType) as e:
+                        except (
+                            FieldValidationFailed,
+                            RequiredField,
+                            InvalidFieldType,
+                        ) as e:
                             allowed_vote_decisions = (
                                 constants_utils.get_all_class_attr_values(
                                     db_constants.VoteDecision


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

Part of #119

### Description of Changes

I wasn't able to recreate the failed archiving example listed in the issue, so I decided to add some logging statements to help debug (and I think it'll be good to have in general). I haven't seen the error occur when I ran the pipeline using the mock data manually, so this should help if it happens in the one of the runs again.

There are a [few different cases](https://github.com/octabytes/FireO/blob/master/src/fireo/fields/field_attribute.py#L99-L115) where FieldValidationFailed is thrown, so the log statement will help narrow down what's causing the validation to fail when we don't expect it to.