### PR TITLE
bugfix/increase-timeout-in-resource-copy

### DIFF
--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -99,7 +99,7 @@ def resource_copy(
 
         # Set custom timeout for http resources
         if uri.startswith("http"):
-            kwargs = {"timeout": aiohttp.ClientTimeout(total=900)}
+            kwargs = {"timeout": aiohttp.ClientTimeout(total=1800)}
 
         # TODO: Add explicit use of GCS credentials until public read is fixed
         fs, remote_path = url_to_fs(uri, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ dev_requirements = [
 ]
 
 requirements = [
+    "aiohttp~=3.7.4.post0",
     "dataclasses-json~=0.5",
     "fireo~=1.4",
     "fsspec",  # Version pin set by gcsfs


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #119 

### Description of Changes

Passing `timeout` to `url_to_fs`. It's kinda convoluted how this happens with `fsspec`, but it goes like this:
1. `url_to_fs` accepts kwargs, and passes it to the implementation that it ends up choosing based on the url you pass it ([link](https://github.com/intake/filesystem_spec/blob/master/fsspec/core.py#L359-L401))
2. In our case, it gets passed to `HttpFileSystem`, and `get` is implemented by it's parent class `AsyncFileSystem` 
3. The timeout val we set as a kwarg in `url_to_fs` somehow gets passed to the [sync](https://github.com/intake/filesystem_spec/blob/master/fsspec/asyn.py#L38-L73) method in `asyn.py` because *I think* all the methods are wrapped with `sync_wrapper`

Here's a [paste](https://pastebin.com/5HzsTEsn) of when I used `pdb` since it's kinda confusing. I was using fsspec 2021.07.0 which is found [here](https://github.com/intake/filesystem_spec/releases/tag/2021.07.0) if you wanna follow line by line exactly.

Unfortunately I think the way to pass a timeout override value varies depending on the fs implementation that `url_to_fs` produces, so this is specific to `http` url's. However I think that's the only uswe case so far where we see this timeout right? I can only think of gcsfs as the only other implementation we use.

I set the timeout to 15 min, which is 3 times the default of 5 minutes. We can adjust more if we see the pipeline is still timing out, but maybe this can be a starting value.