### PR TITLE
bugfix/host-videos-under-more-scenarios

### DIFF
--- a/cdp_backend/bin/process_special_event.py
+++ b/cdp_backend/bin/process_special_event.py
@@ -94,7 +94,8 @@ def main() -> None:
         # Create event gather pipeline flow
         log.info("Beginning processing...")
         flow = pipeline.create_event_gather_flow(
-            config=config, prefetched_events=[ingestion_model], from_local=True
+            config=config,
+            prefetched_events=[ingestion_model],
         )
 
         # Run flow

--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -204,6 +204,7 @@ def create_event(
 
 def create_session(
     session: ingestion_models.Session,
+    session_video_hosted_url: str,
     event_ref: db_models.Event,
     credentials_file: Optional[str] = None,
 ) -> db_models.Session:
@@ -217,7 +218,7 @@ def create_session(
     # Required fields
     db_session.event_ref = event_ref
     db_session.session_datetime = session.session_datetime
-    db_session.video_uri = session.video_uri
+    db_session.video_uri = session_video_hosted_url
     db_session.session_index = session.session_index
 
     # Optional fields

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -8,6 +8,7 @@ from typing import Callable, List, Optional, Type
 
 import requests
 from fireo.models import Model
+from fsspec.core import url_to_fs
 from gcsfs import GCSFileSystem
 
 from ..utils.constants_utils import get_all_class_attr_values
@@ -147,8 +148,12 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
         except requests.exceptions.SSLError:
             return False
 
-    # Check local filesystem
-    return False
+    # Get any filesystem and try
+    try:
+        fs, path = url_to_fs(uri)
+        return fs.exists(path)
+    except Exception:
+        return False
 
 
 def create_constant_value_validator(

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -8,7 +8,6 @@ from typing import Callable, List, Optional, Type
 
 import requests
 from fireo.models import Model
-from fsspec.implementations.local import LocalFileSystem
 from gcsfs import GCSFileSystem
 
 from ..utils.constants_utils import get_all_class_attr_values
@@ -118,22 +117,25 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
         return True
 
     if uri.startswith("gs://") or uri.startswith("https://storage.googleapis"):
+        # Convert to gsutil form if necessary
+        if uri.startswith("https://storage.googleapis"):
+            uri = convert_gcs_json_url_to_gsutil_form(uri)
+
+            # If uri is not convertible to gsutil form we can't confirm
+            if uri == "":
+                return False
+
         if kwargs.get("google_credentials_file"):
-            fs = GCSFileSystem(token=str(kwargs.get("google_credentials_file")))
-
-            # Convert to gsutil form if necessary
-            if uri.startswith("https://storage.googleapis"):
-                uri = convert_gcs_json_url_to_gsutil_form(uri)
-
-                # If uri is not convertible to gsutil form we can't confirm
-                if uri == "":
-                    return True
-
+            fs = GCSFileSystem(token=str(kwargs.get("google_credentials_file", "anon")))
             return fs.exists(uri)
 
         # Can't check GCS resources without creds file
         else:
-            return True
+            try:
+                anon_fs = GCSFileSystem(token="anon")
+                return anon_fs.exists(uri)
+            except Exception:
+                return False
 
     # Is HTTP remote resource
     elif uri.startswith("http"):
@@ -146,9 +148,7 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
             return False
 
     # Check local filesystem
-    else:
-        fs = LocalFileSystem()
-        return fs.exists(uri)
+    return False
 
 
 def create_constant_value_validator(

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -137,10 +137,13 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
 
     # Is HTTP remote resource
     elif uri.startswith("http"):
-        # Use HEAD request to check if remote resource exists
-        r = requests.head(uri)
+        try:
+            # Use HEAD request to check if remote resource exists
+            r = requests.head(uri)
 
-        return r.status_code == requests.codes.ok
+            return r.status_code == requests.codes.ok
+        except requests.exceptions.SSLError:
+            return False
 
     # Check local filesystem
     else:

--- a/cdp_backend/file_store/functions.py
+++ b/cdp_backend/file_store/functions.py
@@ -126,6 +126,28 @@ def upload_file(
         return save_url
 
 
+def get_open_url_for_gcs_file(credentials_file: str, uri: str) -> str:
+    """
+    Simple wrapper around fsspec.FileSystem.url function for creating a connection
+    to the filesystem then getting the hosted / web accessible URL to the file.
+
+    Parameters
+    ----------
+    credentials_file: str
+        The path to the Google Service Account credentials JSON file used
+        to initialize the file store connection.
+    uri: str
+        The URI to the file already stored to get a web accessible URL for.
+
+    Returns
+    -------
+    url: str
+        The web accessible URL for the file.
+    """
+    fs = initialize_gcs_file_system(credentials_file=credentials_file)
+    return str(fs.url(uri))
+
+
 def remove_local_file(filepath: Union[str, Path]) -> None:
     """
     Deletes a file from the local file system.

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -365,9 +365,6 @@ def convert_video_and_handle_host(
             save_name=f"{session_content_hash}-video.mp4",
         )
 
-        # Set session video_uri to uri in remote file store
-        session.video_uri = hosted_video_uri
-
         # Create fs to generate hosted media URL
         hosted_video_media_url = fs_functions.get_open_url_for_gcs_file(
             credentials_file=credentials_file,

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -963,7 +963,8 @@ def _process_person_ingestion(
         if person.picture_uri is not None:
             try:
                 tmp_person_picture_path = file_utils.resource_copy(
-                    person.picture_uri,
+                    uri=person.picture_uri,
+                    dst=f"{person.name}--person_picture",
                     overwrite=True,
                 )
                 destination_path = file_utils.generate_file_storage_name(
@@ -1029,6 +1030,7 @@ def _process_person_ingestion(
                 if person.seat.image_uri is not None:
                     tmp_person_seat_image_path = file_utils.resource_copy(
                         uri=person.seat.image_uri,
+                        dst=f"{person.name}--{person.seat.name}--seat_image",
                         overwrite=True,
                     )
                     destination_path = file_utils.generate_file_storage_name(
@@ -1125,7 +1127,7 @@ def _calculate_in_majority(
     vote: ingestion_models.Vote,
     event_minutes_item: ingestion_models.EventMinutesItem,
 ) -> Optional[bool]:
-    # Voted to Approve or Approve-by-abstention-or-absense
+    # Voted to Approve or Approve-by-abstention-or-absence
     if vote.decision in [
         db_constants.VoteDecision.APPROVE,
         db_constants.VoteDecision.ABSTAIN_APPROVE,
@@ -1135,7 +1137,7 @@ def _calculate_in_majority(
             event_minutes_item.decision == db_constants.EventMinutesItemDecision.PASSED
         )
 
-    # Voted to Reject or Reject-by-abstention-or-absense
+    # Voted to Reject or Reject-by-abstention-or-absence
     elif vote.decision in [
         db_constants.VoteDecision.REJECT,
         db_constants.VoteDecision.ABSTAIN_REJECT,

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -351,6 +351,8 @@ def convert_video_and_handle_host(
         # but not for streaming / hosting
         else:
             cdp_will_host = True
+    else:
+        hosted_video_media_url = session.video_uri
 
     # Upload and swap if cdp is hosting
     if cdp_will_host:
@@ -367,10 +369,10 @@ def convert_video_and_handle_host(
         session.video_uri = hosted_video_uri
 
         # Create fs to generate hosted media URL
-        fs = GCSFileSystem(token=credentials_file)
-        hosted_video_media_url = str(fs.url(hosted_video_uri))
-    else:
-        hosted_video_media_url = session.video_uri
+        hosted_video_media_url = fs_functions.get_open_url_for_gcs_file(
+            credentials_file=credentials_file,
+            uri=hosted_video_uri,
+        )
 
     return video_filepath, hosted_video_media_url
 

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -94,17 +94,22 @@ def test_local_resource_exists(
         ("gs://bucket/filename.txt", True, True, validator_kwargs),
         (
             "https://storage.googleapis.com/download/storage/v1/b/"
-            + "bucket.appspot.com/o/wombo_combo.mp4?alt=media",
+            "bucket.appspot.com/o/wombo_combo.mp4?alt=media",
             True,
             True,
             validator_kwargs,
         ),
         ("gs://bucket/filename.txt", False, False, validator_kwargs),
         # Unconvertible JSON url case
+        # This test was updated 2021-11-30
+        # "Breaking change" in that we can now test for resource access with
+        # anonymous credentials
+        # Whatever resource is handed to us we want to check for existence.
+        # If the resource isn't reachable then from our POV, it doesn't exist.
         (
             "https://storage.googleapis.com/download/storage/v1/xxx/"
-            + "bucket.appspot.com",
-            True,
+            "bucket.appspot.com",
+            False,
             None,
             None,
         ),

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -91,6 +91,13 @@ def resource_copy(
     dst = Path(dst).resolve()
     if dst.is_dir():
         dst = dst / uri.split("/")[-1]
+
+    # Ensure filename is less than 255 chars
+    # Otherwise this can raise an OSError for too long of a filename
+    if len(dst.name) > 255:
+        dst = Path(str(dst)[:255])
+
+    # Ensure dest isn't a file
     if dst.is_file() and not overwrite:
         raise FileExistsError(dst)
 

--- a/dev-infrastructure/Makefile
+++ b/dev-infrastructure/Makefile
@@ -41,6 +41,10 @@ clean: ## Remove all database documents and filestore objects
 	clean_cdp_database ../.keys/cdp-dev.json
 	clean_cdp_filestore ../.keys/cdp-dev.json
 
+clean-full: ## Remove all database documents and files, include indexs
+	clean_cdp_database ../.keys/cdp-dev.json --clean-index
+	clean_cdp_filestore ../.keys/cdp-dev.json
+
 reset: ## Run pulumi destroy and make build, must provide "project"
 	pulumi destroy -p 4
 	echo "----------------------------------------------------------------------------"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

_Include a description of the proposed changes._

Major goal of this work is to host the video file provided to us from scraper under more scenarios.

However in addition to that, I added an option to the clean database function that allows the skipping of cleaning the index collections because those take a long time to fully delete. Additionally, I fix a bug I found while running the pipeline for king county which was that king county has some files that have names longer than 255 characters which Ubuntu doesn't like.

I can't seem to figure out why these changes will work in synchronous mode but not in parallel...