### PR TITLE
bugfix/use-consistent-datetime-in-hash-generation

### DIFF
--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -39,10 +39,7 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
         The updated database model with the doc key set.
     """
     # Create hasher and hash primary values
-    print(db_model)
-    print("OG ID: " + str(db_model.id))
     hasher = sha256()
-    print(type(db_model))
     for pk in db_model._PRIMARY_KEYS:
         field = getattr(db_model, pk)
 
@@ -51,14 +48,10 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
             # Ensure that the underlying model has an id
             # In place update to db_model for this field
 
-            print(type(field))
-            print("PRE GENERATE FIELD ID " + str(field.id))
             setattr(db_model, pk, generate_and_attach_doc_hash_as_id(field))
 
             # Update variable after setattr
             field = getattr(db_model, pk)
-            print(type(field))
-            print("GENERATED FIELD ID " + str(field.id))
 
             # Now attach the generated hash document path
             hasher.update(pickle.dumps(field.id, protocol=4))
@@ -67,22 +60,16 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
         else:
             # Load the document for reference fields and add id to hasher
             if isinstance(field, ReferenceDocLoader):
-                print("REFERENCE DOC of " + str(type(field.get())))
-                print("HASHING REFERENCE WITH ID: " + str(field.get().id))
                 hasher.update(pickle.dumps(field.get().id, protocol=4))
             else:
+                # If datetime, hash with epoch millis to avoid timezone issues
                 if isinstance(field, datetime):
-                    print("A DATETIME")
                     field = field.timestamp()
-                    print("CONVERTING DATETIME TO " + str(field))
-                print("NORMAL CASE of " + str(type(field)))
-                print("HASHING " + pk + " "  + str(field))
                 hasher.update(pickle.dumps(field, protocol=4))
 
     # Set the id to the first twelve characters of hexdigest
     end_hash = hasher.hexdigest()[:12]
     db_model.id = end_hash
-    print("FINAL HASH for " + str(db_model) + str(end_hash))
 
     return db_model
 

--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -59,11 +59,13 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
             # Now attach the generated hash document path
             hasher.update(pickle.dumps(field.id, protocol=4))
 
+        # If datetime, hash with epoch millis to avoid timezone issues
+        elif isinstance(field, datetime):
+            field = field.timestamp()
+            hasher.update(pickle.dumps(field, protocol=4))
+
         # Otherwise just simply add the primary key value
         else:
-            # If datetime, hash with epoch millis to avoid timezone issues
-            if isinstance(field, datetime):
-                field = field.timestamp()
             hasher.update(pickle.dumps(field, protocol=4))
 
     # Set the id to the first twelve characters of hexdigest

--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -53,13 +53,15 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
 
             print(type(field))
             print("PRE GENERATE FIELD ID " + str(field.id))
-            new_field = generate_and_attach_doc_hash_as_id(field)
-            setattr(db_model, pk, new_field)
+            setattr(db_model, pk, generate_and_attach_doc_hash_as_id(field))
+
+            # Update variable after setattr
+            field = getattr(db_model, pk)
             print(type(field))
-            print("GENERATED FIELD ID " + str(new_field.id))
+            print("GENERATED FIELD ID " + str(field.id))
 
             # Now attach the generated hash document path
-            hasher.update(pickle.dumps(new_field.id, protocol=4))
+            hasher.update(pickle.dumps(field.id, protocol=4))
 
         # Otherwise just simply add the primary key value
         else:

--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -67,8 +67,7 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
                 hasher.update(pickle.dumps(field, protocol=4))
 
     # Set the id to the first twelve characters of hexdigest
-    end_hash = hasher.hexdigest()[:12]
-    db_model.id = end_hash
+    db_model.id = hasher.hexdigest()[:12]
 
     return db_model
 

--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -47,7 +47,6 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
         if isinstance(field, Model):
             # Ensure that the underlying model has an id
             # In place update to db_model for this field
-
             setattr(db_model, pk, generate_and_attach_doc_hash_as_id(field))
 
             # Update variable after setattr

--- a/cdp_backend/database/functions.py
+++ b/cdp_backend/database/functions.py
@@ -43,8 +43,12 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
     for pk in db_model._PRIMARY_KEYS:
         field = getattr(db_model, pk)
 
+        # Load the document for reference fields and add id to hasher
+        if isinstance(field, ReferenceDocLoader):
+            hasher.update(pickle.dumps(field.get().id, protocol=4))
+
         # Handle reference fields by using their doc path
-        if isinstance(field, Model):
+        elif isinstance(field, Model):
             # Ensure that the underlying model has an id
             # In place update to db_model for this field
             setattr(db_model, pk, generate_and_attach_doc_hash_as_id(field))
@@ -57,14 +61,10 @@ def generate_and_attach_doc_hash_as_id(db_model: Model) -> Model:
 
         # Otherwise just simply add the primary key value
         else:
-            # Load the document for reference fields and add id to hasher
-            if isinstance(field, ReferenceDocLoader):
-                hasher.update(pickle.dumps(field.get().id, protocol=4))
-            else:
-                # If datetime, hash with epoch millis to avoid timezone issues
-                if isinstance(field, datetime):
-                    field = field.timestamp()
-                hasher.update(pickle.dumps(field, protocol=4))
+            # If datetime, hash with epoch millis to avoid timezone issues
+            if isinstance(field, datetime):
+                field = field.timestamp()
+            hasher.update(pickle.dumps(field, protocol=4))
 
     # Set the id to the first twelve characters of hexdigest
     db_model.id = hasher.hexdigest()[:12]

--- a/cdp_backend/tests/database/test_functions.py
+++ b/cdp_backend/tests/database/test_functions.py
@@ -2,19 +2,31 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+import pytz
+
+from datetime import datetime, timezone
 from fireo.models import Model
 
 from cdp_backend.database import functions as db_functions
 from cdp_backend.database import models as db_models
 
 ###############################################################################
-# Tests
+# Test constants
 
 body_a = db_models.Body()
 body_a.name = "Body A"
 
 body_b = db_models.Body()
 body_b.name = "Body B"
+
+a_datetime = datetime.fromisoformat("2021-08-16 07:42:10.318957+00:00")
+event_a = db_models.Event.Example()
+event_a.event_datetime = a_datetime
+
+event_b = db_models.Event.Example()
+local_tz = pytz.timezone('Europe/Moscow')
+modified_dt = event_a.event_datetime.replace(tzinfo=timezone.utc).astimezone(tz=local_tz)
+event_b.event_datetime = local_tz.normalize(modified_dt)
 
 
 @pytest.mark.parametrize(
@@ -27,6 +39,9 @@ body_b.name = "Body B"
         # Testing models differ
         (body_a, "0a8a8e139258"),
         (body_b, "1535fef479ff"),
+        # Testing timezone difference
+        (event_a, "6291946d4094"),
+        (event_b, "6291946d4094")
     ],
 )
 def test_generate_and_attach_doc_hash_as_id(model: Model, expected_id: str) -> None:

--- a/cdp_backend/tests/database/test_functions.py
+++ b/cdp_backend/tests/database/test_functions.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from datetime import datetime, timezone
+
 import pytest
 import pytz
-
-from datetime import datetime, timezone
 from fireo.models import Model
 
 from cdp_backend.database import functions as db_functions
@@ -24,8 +24,10 @@ event_a = db_models.Event.Example()
 event_a.event_datetime = a_datetime
 
 event_b = db_models.Event.Example()
-local_tz = pytz.timezone('Europe/Moscow')
-modified_dt = event_a.event_datetime.replace(tzinfo=timezone.utc).astimezone(tz=local_tz)
+local_tz = pytz.timezone("Europe/Moscow")
+modified_dt = event_a.event_datetime.replace(tzinfo=timezone.utc).astimezone(
+    tz=local_tz
+)
 event_b.event_datetime = local_tz.normalize(modified_dt)
 
 
@@ -41,7 +43,7 @@ event_b.event_datetime = local_tz.normalize(modified_dt)
         (body_b, "1535fef479ff"),
         # Testing timezone difference
         (event_a, "6291946d4094"),
-        (event_b, "6291946d4094")
+        (event_b, "6291946d4094"),
     ],
 )
 def test_generate_and_attach_doc_hash_as_id(model: Model, expected_id: str) -> None:

--- a/dev-infrastructure/README.md
+++ b/dev-infrastructure/README.md
@@ -9,7 +9,7 @@ Full infrastructure setup for whole system / integration level testing.
 This is primarily used for developer stack creation and management.
 We have an example stack, infrastructure, pipeline, and web app available for
 demonstration and example data usage in our
-[example repo](https://github.com/CouncilDataProject/example).
+[example repo](https://github.com/CouncilDataProject/test-deployment).
 
 If you are just trying to process example CDP data (or for front-end: visualize example
 CDP data) and not _upload_ data, it is recommended to simply point your requests at the

--- a/dev-infrastructure/README.md
+++ b/dev-infrastructure/README.md
@@ -9,7 +9,9 @@ Full infrastructure setup for whole system / integration level testing.
 This is primarily used for developer stack creation and management.
 We have an example stack, infrastructure, pipeline, and web app available for
 demonstration and example data usage in our
-[example repo](https://github.com/CouncilDataProject/test-deployment).
+[test deployment repo](https://github.com/CouncilDataProject/test-deployment).
+The web page for the test deployment can be found 
+[here](https://councildataproject.org/test-deployment).
 
 If you are just trying to process example CDP data (or for front-end: visualize example
 CDP data) and not _upload_ data, it is recommended to simply point your requests at the


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #142 

### Description of Changes

When we hash with a `datetime` field, we keep timezone agnostic by converting the datetime to epoch millis. This keeps hashing consistent. I also refreshed the `field` variable after `setattr` just for sanity. 

Most of the background context can be found in the linked issue. 

### Testing:
You can see from the logs below that event hash is now consistent by searching for `FINAL HASH for <cdp_backend.database.models.Event object at`:
https://pastebin.com/dG8c3wRd 
- The print statements can be seen [here](https://github.com/CouncilDataProject/cdp-backend/commit/401c4da3204af840db511f7f1aa1a52cc2f6e3c6)

I also ran the following script to check that session is now consistent upon regeneration: 
```python
from cdp_backend.database import models as db_models
import fireo
from google.auth.credentials import AnonymousCredentials
from google.cloud.firestore import Client
from cdp_backend.database.functions import generate_and_attach_doc_hash_as_id

# Connect to the database
fireo.connection(client=Client(
    project="stg-cdp-seattle-isaac",
    credentials=AnonymousCredentials()
))

def print_session_hashes(event_id):
    event = db_models.Event.collection.get(f"{db_models.Event.collection_name}/{event_id}")
    print("EVENT ID: " + str(event.id))
    sessions = list(db_models.Session.collection.filter("event_ref", "==", event.key).fetch())
    for session in sessions:
        print("OLD: " + str(session.id))
        updated = generate_and_attach_doc_hash_as_id(session)
        print("UPDATED: " + str(updated.id))

print_session_hashes("6291946d4094")
"""
Prints:
EVENT ID: 6291946d4094
OLD: 7567518a5998
UPDATED: 7567518a5998

OLD: 97a4f821a3e7
UPDATED: 97a4f821a3e7

"""

```