### PR TITLE
bugfix/dont-fail-pipeline-on-bad-picture-urls

### DIFF
--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -8,6 +8,7 @@ from operator import attrgetter
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
+from aiohttp.client_exceptions import ClientResponseError
 from fireo.fields.errors import FieldValidationFailed, InvalidFieldType, RequiredField
 from fsspec.core import url_to_fs
 from gcsfs import GCSFileSystem
@@ -1000,11 +1001,11 @@ def _process_person_ingestion(
                     db_model=person_picture_db_model,
                     credentials_file=credentials_file,
                 )
-            except FileNotFoundError:
+            except (FileNotFoundError, ClientResponseError) as e:
                 person_picture_db_model = None
                 log.warning(
                     f"Person ('{person.name}'), picture URI could not be archived."
-                    f"({person.picture_uri})"
+                    f"({person.picture_uri}). Error: {e}"
                 )
         else:
             person_picture_db_model = None
@@ -1068,11 +1069,11 @@ def _process_person_ingestion(
                 else:
                     person_seat_image_db_model = None
 
-            except FileNotFoundError:
+            except (FileNotFoundError, ClientResponseError) as e:
                 person_seat_image_db_model = None
                 log.warning(
                     f"Person ('{person.name}'), seat image URI could not be archived."
-                    f"({person.seat.image_uri})"
+                    f"({person.seat.image_uri}). Error: {e}"
                 )
 
             # Actual seat creation


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

_Include a description of the proposed changes._

This PR fixes or adds a feature (depending on how you look at it). We are experiencing some failures on the King County reprocessing: https://github.com/CouncilDataProject/king-county/runs/4729015978?check_suite_focus=true

This is due to the seat images failing to download, not because they have moved or don't exist but because our request has been denied by the host. This change makes it so that the pipeline will simply log the error and continue the rest of the pipeline. This imo is completely fine as seat and person images are optional anyway.

cc @dphoria because we probably want to update the king county seat images :joy: 
