### PR TITLE
feature/role-title-constants

### DIFF
--- a/cdp_backend/database/constants.py
+++ b/cdp_backend/database/constants.py
@@ -38,3 +38,12 @@ class MatterStatusDecision:
     ADOPTED = "Adopted"
     REJECTED = "Rejected"
     IN_PROGRESS = "In Progress"
+
+
+class RoleTitle:
+    councilmember = "Councilmember"
+    president = "President"
+    chair = "Chair"
+    vice_chair = "Vice Chair"
+    alternate = "Alternate"
+    member = "Member"

--- a/cdp_backend/database/constants.py
+++ b/cdp_backend/database/constants.py
@@ -42,7 +42,7 @@ class MatterStatusDecision:
 
 class RoleTitle:
     COUNCILMEMBER = "Councilmember"
-    PRESIDENT = "President"
+    COUNCILPRESIDENT = "Council President"
     CHAIR = "Chair"
     VICE_CHAIR = "Vice Chair"
     ALTERNATE = "Alternate"

--- a/cdp_backend/database/constants.py
+++ b/cdp_backend/database/constants.py
@@ -41,9 +41,9 @@ class MatterStatusDecision:
 
 
 class RoleTitle:
-    councilmember = "Councilmember"
-    president = "President"
-    chair = "Chair"
-    vice_chair = "Vice Chair"
-    alternate = "Alternate"
-    member = "Member"
+    COUNCILMEMBER = "Councilmember"
+    PRESIDENT = "President"
+    CHAIR = "Chair"
+    VICE_CHAIR = "Vice Chair"
+    ALTERNATE = "Alternate"
+    MEMBER = "Member"

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -189,9 +189,7 @@ class Role(Model):
 
     id = fields.IDField()
     title = fields.TextField(
-        validator=validators.create_constant_value_validator(
-            RoleTitle, True
-        )
+        validator=validators.create_constant_value_validator(RoleTitle, True)
     )
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     body_ref = fields.ReferenceField(Body, auto_load=False)

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -204,7 +204,7 @@ class Role(Model):
     @classmethod
     def Example(cls) -> Model:
         role = cls()
-        role.title = RoleTitle.PRESIDENT
+        role.title = RoleTitle.COUNCILPRESIDENT
         role.person_ref = Person.Example()
         role.body_ref = Body.Example()
         role.seat_ref = Seat.Example()

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -189,7 +189,8 @@ class Role(Model):
 
     id = fields.IDField()
     title = fields.TextField(
-        validator=validators.create_constant_value_validator(RoleTitle, True)
+        required=True,
+        validator=validators.create_constant_value_validator(RoleTitle, True),
     )
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     body_ref = fields.ReferenceField(Body, auto_load=False)

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -15,6 +15,7 @@ from .constants import (
     EventMinutesItemDecision,
     MatterStatusDecision,
     Order,
+    RoleTitle,
     VoteDecision,
 )
 from .types import IndexedField, IndexedFieldSet
@@ -187,7 +188,11 @@ class Role(Model):
     """
 
     id = fields.IDField()
-    title = fields.TextField(required=True)
+    title = fields.TextField(
+        validator=validators.create_constant_value_validator(
+            RoleTitle, True
+        )
+    )
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     body_ref = fields.ReferenceField(Body, auto_load=False)
     seat_ref = fields.ReferenceField(Seat, required=True, auto_load=False)
@@ -201,7 +206,7 @@ class Role(Model):
     @classmethod
     def Example(cls) -> Model:
         role = cls()
-        role.title = "Council President"
+        role.title = RoleTitle.PRESIDENT
         role.person_ref = Person.Example()
         role.body_ref = Body.Example()
         role.seat_ref = Seat.Example()

--- a/cdp_backend/pipeline/mock_get_events.py
+++ b/cdp_backend/pipeline/mock_get_events.py
@@ -9,6 +9,7 @@ from typing import Any, List
 from ..database.constants import (
     EventMinutesItemDecision,
     MatterStatusDecision,
+    RoleTitle,
     VoteDecision,
 )
 from ..utils.constants_utils import get_all_class_attr_values
@@ -76,14 +77,14 @@ def _get_example_person(seat_num: int) -> Person:
     """
     # Create a list of roles
     roles = [
-        Role(title="Councilmember", body=Body(name="Example Committee")),
-        Role(title="Chair", body=Body(name=f"Example Committee {seat_num}")),
+        Role(title=RoleTitle.COUNCILMEMBER, body=Body(name="Example Committee")),
+        Role(title=RoleTitle.CHAIR, body=Body(name=f"Example Committee {seat_num}")),
     ]
 
     # Add Council President role for seat position 1
     if seat_num == 1:
         roles.append(
-            Role(title="Council President", body=Body(name="Example Committee"))
+            Role(title=RoleTitle.COUNCILPRESIDENT, body=Body(name="Example Committee"))
         )
 
     # Get the seat electoral type num

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -10,6 +10,7 @@ from cdp_backend.database import models, validators
 from cdp_backend.database.constants import (
     EventMinutesItemDecision,
     MatterStatusDecision,
+    RoleTitle,
     VoteDecision,
 )
 
@@ -177,4 +178,20 @@ def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -
         MatterStatusDecision, True
     )
     actual_result = validator_func(decision)
+    assert actual_result == expected_result
+
+
+@pytest.mark.parametrize(
+    "title, expected_result",
+    [
+        (None, False),
+        ("Councilmember", True),
+        ("INVALID", False),
+    ],
+)
+def test_role_title_is_valid(title: str, expected_result: bool) -> None:
+    validator_func = validators.create_constant_value_validator(
+        RoleTitle, True
+    )
+    actual_result = validator_func(title)
     assert actual_result == expected_result

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -190,8 +190,6 @@ def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -
     ],
 )
 def test_role_title_is_valid(title: str, expected_result: bool) -> None:
-    validator_func = validators.create_constant_value_validator(
-        RoleTitle, True
-    )
+    validator_func = validators.create_constant_value_validator(RoleTitle, True)
     actual_result = validator_func(title)
     assert actual_result == expected_result


### PR DESCRIPTION
### Link to Relevant Issue

This pull request is a prerequisite for resolving https://github.com/CouncilDataProject/cdp-scrapers/issues/66

### Description of Changes

_Include a description of the proposed changes._

Added `RoleTitle` string constants to `cdp_backend/database/constants.py`. This will be useful for `cdp_scrapers` when applying logic to ensure that a `Person` has only one `Role` with `title = RoleTitle.COUNCILMEMBER` per term.

I took `RoleTitle` members verbatim from Jackson's suggestions in this [comment](https://github.com/CouncilDataProject/cdp-scrapers/issues/66#issuecomment-1012578579). Certainly open to additions, modifications, etc.

For reference, below is the entire unique list of `OfficeRecordTitle` from all Legistar API `OfficeRecords` in Seattle.

```
Vice Chair
Member
Chair
Councilmember
City Clerk
None
Alternate
Mayor
Council President
```
(You gotta love `None` :rofl: )

For `OfficeRecordMemberType`,

```
Chair
Vice Chair
Member
```