### PR TITLE
bug/catch-timeout-in-event-gather

### DIFF
--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -14,6 +14,7 @@ from fsspec.core import url_to_fs
 from gcsfs import GCSFileSystem
 from prefect import Flow, task
 from prefect.tasks.control_flow import case, merge
+from requests import ConnectionError
 
 from ..database import constants as db_constants
 from ..database import functions as db_functions
@@ -1001,7 +1002,7 @@ def _process_person_ingestion(
                     db_model=person_picture_db_model,
                     credentials_file=credentials_file,
                 )
-            except (FileNotFoundError, ClientResponseError) as e:
+            except (FileNotFoundError, ClientResponseError, ConnectionError) as e:
                 person_picture_db_model = None
                 log.warning(
                     f"Person ('{person.name}'), picture URI could not be archived."
@@ -1021,7 +1022,12 @@ def _process_person_ingestion(
                 db_model=person_db_model,
                 credentials_file=credentials_file,
             )
-        except (FieldValidationFailed, RequiredField, InvalidFieldType):
+        except (
+            FieldValidationFailed,
+            RequiredField,
+            InvalidFieldType,
+            ConnectionError,
+        ):
             log.warning(
                 f"Person ({person_db_model.to_dict()}), "
                 f"was missing required information. Generating minimum person details."
@@ -1069,7 +1075,7 @@ def _process_person_ingestion(
                 else:
                     person_seat_image_db_model = None
 
-            except (FileNotFoundError, ClientResponseError) as e:
+            except (FileNotFoundError, ClientResponseError, ConnectionError) as e:
                 person_seat_image_db_model = None
                 log.warning(
                     f"Person ('{person.name}'), seat image URI could not be archived."
@@ -1441,10 +1447,10 @@ def store_event_processing_results(
                                 db_model=matter_file_db_model,
                                 credentials_file=credentials_file,
                             )
-                        except FieldValidationFailed:
-                            log.error(
+                        except (FieldValidationFailed, ConnectionError) as e:
+                            log.warning(
                                 f"MatterFile ('{supporting_file.uri}') "
-                                f"could not be archived. Skipping."
+                                f"could not be archived. Skipping. Error: {e}"
                             )
 
                     # Archive as event minutes item file
@@ -1460,10 +1466,10 @@ def store_event_processing_results(
                             db_model=event_minutes_item_file_db_model,
                             credentials_file=credentials_file,
                         )
-                    except FieldValidationFailed:
+                    except (FieldValidationFailed, ConnectionError) as e:
                         log.error(
                             f"EventMinutesItemFile ('{supporting_file.uri}') "
-                            f"could not be archived."
+                            f"could not be archived. Error: {e}"
                         )
 
             # Add vote information

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -1004,7 +1004,7 @@ def _process_person_ingestion(
                 )
             except (FileNotFoundError, ClientResponseError, ConnectionError) as e:
                 person_picture_db_model = None
-                log.warning(
+                log.error(
                     f"Person ('{person.name}'), picture URI could not be archived."
                     f"({person.picture_uri}). Error: {e}"
                 )
@@ -1028,7 +1028,7 @@ def _process_person_ingestion(
             InvalidFieldType,
             ConnectionError,
         ):
-            log.warning(
+            log.error(
                 f"Person ({person_db_model.to_dict()}), "
                 f"was missing required information. Generating minimum person details."
             )
@@ -1077,7 +1077,7 @@ def _process_person_ingestion(
 
             except (FileNotFoundError, ClientResponseError, ConnectionError) as e:
                 person_seat_image_db_model = None
-                log.warning(
+                log.error(
                     f"Person ('{person.name}'), seat image URI could not be archived."
                     f"({person.seat.image_uri}). Error: {e}"
                 )
@@ -1246,8 +1246,8 @@ def store_event_processing_results(
             db_model=event_db_model,
             credentials_file=credentials_file,
         )
-    except FieldValidationFailed:
-        log.warning(
+    except (FieldValidationFailed, ConnectionError):
+        log.error(
             f"Agenda and/or minutes docs could not be found. "
             f"Adding event without agenda and minutes URIs. "
             f"({event.agenda_uri} AND/OR {event.minutes_uri} do not exist)"
@@ -1448,7 +1448,7 @@ def store_event_processing_results(
                                 credentials_file=credentials_file,
                             )
                         except (FieldValidationFailed, ConnectionError) as e:
-                            log.warning(
+                            log.error(
                                 f"MatterFile ('{supporting_file.uri}') "
                                 f"could not be archived. Skipping. Error: {e}"
                             )


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #154 

### Description of Changes

The [error here](https://github.com/CouncilDataProject/seattle-staging/runs/4930903577?check_suite_focus=true) was caused by a `requests.ConnectionError`. 

I added a catch for `ConnectionError` for every `try` statement that uploads a db model and has `resource_exists` validation. 

I'm assuming that wherever we don't have a `try` statement, we wouldn't want to proceed in the pipeline if something errors out during that `upload_db_model` step. But let me know if this assumption isn't correct

