### PR TITLE
feature/script-for-retroactive-session-content-hashing

### DIFF
--- a/cdp_backend/bin/add_content_hash_to_sessions.py
+++ b/cdp_backend/bin/add_content_hash_to_sessions.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import fireo
 
-from cdp_backend.database import models as db_models
 from cdp_backend.database.models import Session, Transcript
 
 ###############################################################################
@@ -30,7 +29,8 @@ class Args(argparse.Namespace):
     def __parse(self) -> None:
         p = argparse.ArgumentParser(
             prog="add_content_hash_to_sessions",
-            description="Add content hash to all existing session rows in the database.",
+            description="Add content hash to all existing session rows in "
+            + "the database.",
         )
         p.add_argument(
             "--google_credentials_file",
@@ -96,10 +96,12 @@ def add_content_hash_to_sessions(google_creds_path: Path) -> None:
             unfixed_sessions.remove(session.id)
 
     # Log any sessions that still don't have a content hash
-    # Could happen if there are db inconsistencies (like a session is orphaned w/o a transcript)
+    # Could happen if there are db inconsistencies
+    # (like a session is orphaned w/o a transcript)
     if unfixed_sessions:
         log.error(
-            f"The following sessions were not fixed with a content hash: {unfixed_sessions}"
+            "The following sessions were not fixed with a "
+            + f"content hash: {unfixed_sessions}"
         )
 
 

--- a/cdp_backend/bin/add_content_hash_to_sessions.py
+++ b/cdp_backend/bin/add_content_hash_to_sessions.py
@@ -30,8 +30,7 @@ class Args(argparse.Namespace):
         p = argparse.ArgumentParser(
             prog="add_content_hash_to_sessions",
             description=(
-                "Add content hash to all existing session rows "  # type: ignore
-                "in the database.",
+                "Add content hash to all existing session rows in the database."
             ),
         )
         p.add_argument(

--- a/cdp_backend/bin/add_content_hash_to_sessions.py
+++ b/cdp_backend/bin/add_content_hash_to_sessions.py
@@ -99,7 +99,7 @@ def add_content_hash_to_sessions(google_creds_path: Path) -> None:
     # Could happen if there are db inconsistencies (like a session is orphaned w/o a transcript)
     if unfixed_sessions:
         log.error(
-            f"The following sessions were not fixed with session content hash: {unfixed_sessions}"
+            f"The following sessions were not fixed with a content hash: {unfixed_sessions}"
         )
 
 

--- a/cdp_backend/bin/add_content_hash_to_sessions.py
+++ b/cdp_backend/bin/add_content_hash_to_sessions.py
@@ -9,9 +9,8 @@ from pathlib import Path
 
 import fireo
 
-from cdp_backend.database.models import Session, Transcript
 from cdp_backend.database import models as db_models
-
+from cdp_backend.database.models import Session, Transcript
 
 ###############################################################################
 
@@ -53,29 +52,29 @@ def add_content_hash_to_sessions(google_creds_path: Path) -> None:
 
     # Sessions without a content hash
     unfixed_sessions = set([s.id for s in sessions if not s.session_content_hash])
-    
-    # Fetch all transcripts 
+
+    # Fetch all transcripts
     transcripts = Transcript.collection.fetch()
-    
+
     # Unfortunately firestore doesn't have built in distinct querying
     # Create list where each transcripts is for a unique session
     transcripts_unique_sessions = list({t.session_ref: t for t in transcripts}.values())
 
     # Fetch all sessions
     for transcript in transcripts_unique_sessions:
-        # Get file db ref 
+        # Get file db ref
         _file = transcript.file_ref.get()
 
         # Get session
         session = transcript.session_ref.get()
 
-        # If no session_content_hash found 
+        # If no session_content_hash found
         if not session.session_content_hash:
             # Extract hash  from file
-            session_content_hash = _file.name.split('-')[0]
-             
-            # Need to set event reference since autoload is disabled, 
-            # and FireO throws an error if the model has a ReferenceDocLoader 
+            session_content_hash = _file.name.split("-")[0]
+
+            # Need to set event reference since autoload is disabled,
+            # and FireO throws an error if the model has a ReferenceDocLoader
             # on a property during any db write action
             session.event_ref = session.event_ref.get()
 
@@ -99,8 +98,10 @@ def add_content_hash_to_sessions(google_creds_path: Path) -> None:
     # Log any sessions that still don't have a content hash
     # Could happen if there are db inconsistencies (like a session is orphaned w/o a transcript)
     if unfixed_sessions:
-        log.error(f"The following sessions were not fixed with session content hash: {unfixed_sessions}")
-        
+        log.error(
+            f"The following sessions were not fixed with session content hash: {unfixed_sessions}"
+        )
+
 
 def main() -> None:
     try:

--- a/cdp_backend/bin/add_content_hash_to_sessions.py
+++ b/cdp_backend/bin/add_content_hash_to_sessions.py
@@ -29,8 +29,10 @@ class Args(argparse.Namespace):
     def __parse(self) -> None:
         p = argparse.ArgumentParser(
             prog="add_content_hash_to_sessions",
-            description="Add content hash to all existing session rows in "
-            + "the database.",
+            description=(
+                "Add content hash to all existing session rows "  # type: ignore
+                "in the database.",
+            ),
         )
         p.add_argument(
             "--google_credentials_file",
@@ -101,7 +103,7 @@ def add_content_hash_to_sessions(google_creds_path: Path) -> None:
     if unfixed_sessions:
         log.error(
             "The following sessions were not fixed with a "
-            + f"content hash: {unfixed_sessions}"
+            f"content hash: {unfixed_sessions}"
         )
 
 

--- a/cdp_backend/bin/add_content_hash_to_sessions.py
+++ b/cdp_backend/bin/add_content_hash_to_sessions.py
@@ -89,7 +89,7 @@ def add_content_hash_to_sessions(google_creds_path: Path) -> None:
             # Upsert existing session
             session.upsert()
 
-            log.info("Updated session " + str(session.id) + " with content hash")
+            log.info(f"Updated session {session.id} with content hash")
 
         # Mark session as fixed
         if session.id in unfixed_sessions:

--- a/cdp_backend/bin/add_content_hash_to_sessions.py
+++ b/cdp_backend/bin/add_content_hash_to_sessions.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import logging
+import sys
+import traceback
+from pathlib import Path
+
+import fireo
+
+from cdp_backend.database.models import Session, Transcript
+from cdp_backend.database import models as db_models
+
+
+###############################################################################
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)4s: %(module)s:%(lineno)4s %(asctime)s] %(message)s",
+)
+log = logging.getLogger(__name__)
+
+###############################################################################
+
+
+class Args(argparse.Namespace):
+    def __init__(self) -> None:
+        self.__parse()
+
+    def __parse(self) -> None:
+        p = argparse.ArgumentParser(
+            prog="add_content_hash_to_sessions",
+            description="Add content hash to all existing session rows in the database.",
+        )
+        p.add_argument(
+            "--google_credentials_file",
+            type=Path,
+            help="Path to Google service account JSON key.",
+        )
+        p.parse_args(namespace=self)
+
+
+###############################################################################
+
+
+def add_content_hash_to_sessions(google_creds_path: Path) -> None:
+    # Connect to database
+    fireo.connection(from_file=google_creds_path)
+
+
+    # Fetch all sessions
+    sessions = Session.collection.fetch()
+
+    # Session set
+    unfixed_sessions = set([s.id for s in sessions])
+    
+    # Fetch all transcripts 
+    transcripts = Transcript.collection.fetch()
+    
+    # Unfortunately firestore doesn't have built in distinct querying
+    # Create list where each transcripts is for a unique session
+    transcripts_unique_sessions = list({t.session_ref: t for t in transcripts}.values())
+
+    # Fetch all sessions
+    for transcript in transcripts_unique_sessions:
+        # Get file db ref 
+        _file = transcript.file_ref.get()
+
+        # Extract hash 
+        session_content_hash = _file.name.split('-')[0]
+
+         
+        # Update session
+        session = transcript.session_ref.get()
+        # Need to set event reference since autoload is disabled
+        session.event_ref = session.event_ref.get()
+
+
+        session.session_content_hash = session_content_hash
+
+        session.set_validator_kwargs(
+        kwargs={"google_credentials_file": str(google_creds_path)}
+        )
+
+
+        # Upsert existign session
+        session.upsert()
+
+        # Mark session as fixed
+        if session.id in unfixed_sessions:
+            unfixed_sessions.remove(session.id)
+
+
+
+    if unfixed_sessions:
+        log.error(f"The following sessions were not fixed with session content hash: {unfixed_sessions}")
+        
+
+def main() -> None:
+    try:
+        args = Args()
+        add_content_hash_to_sessions(
+            google_creds_path=args.google_credentials_file,
+        )
+    except Exception as e:
+        log.error("=============================================")
+        log.error("\n\n" + traceback.format_exc())
+        log.error("=============================================")
+        log.error("\n\n" + str(e) + "\n")
+        log.error("=============================================")
+        sys.exit(1)

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -122,25 +122,20 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
         if uri.startswith("https://storage.googleapis"):
             uri = convert_gcs_json_url_to_gsutil_form(uri)
 
-            #print("URI!!!")
-            #print(uri)
             # If uri is not convertible to gsutil form we can't confirm
             if uri == "":
                 return False
 
         if kwargs.get("google_credentials_file"):
-            #print("HERE")
             fs = GCSFileSystem(token=str(kwargs.get("google_credentials_file", "anon")))
             return fs.exists(uri)
 
         # Can't check GCS resources without creds file
         else:
             try:
-                #print("AAAAA")
                 anon_fs = GCSFileSystem(token="anon")
                 return anon_fs.exists(uri)
             except Exception:
-                #print("RIP")
                 return False
 
     # Is HTTP remote resource

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -122,20 +122,25 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
         if uri.startswith("https://storage.googleapis"):
             uri = convert_gcs_json_url_to_gsutil_form(uri)
 
+            #print("URI!!!")
+            #print(uri)
             # If uri is not convertible to gsutil form we can't confirm
             if uri == "":
                 return False
 
         if kwargs.get("google_credentials_file"):
+            #print("HERE")
             fs = GCSFileSystem(token=str(kwargs.get("google_credentials_file", "anon")))
             return fs.exists(uri)
 
         # Can't check GCS resources without creds file
         else:
             try:
+                #print("AAAAA")
                 anon_fs = GCSFileSystem(token="anon")
                 return anon_fs.exists(uri)
             except Exception:
+                #print("RIP")
                 return False
 
     # Is HTTP remote resource

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
             "run_cdp_event_index=cdp_backend.bin.run_cdp_event_index:main",
             "search_cdp_events=cdp_backend.bin.search_cdp_events:main",
             "process_special_event=cdp_backend.bin.process_special_event:main",
+            "add_content_hash_to_sessions=cdp_backend.bin.add_content_hash_to_sessions:main",
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #158 

### Description of Changes

Added a script for adding the content hash for every session in a firestore instance. 

Running this script would be:
```
add_content_hash_to_sessions --google_credentials_file {PATH_TO_CREDS_FILE}
```

### Testing

Ran this on my personal firestore instance and tested the following:
- All session content hashes are added
- We properly log which sessions still don't have the content hashes
