### PR TITLE
bugfix/revert-validator-fixes

### DIFF
--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -190,7 +190,7 @@ class Role(Model):
     id = fields.IDField()
     title = fields.TextField(
         required=True,
-        validator=validators.create_constant_value_validator(RoleTitle),
+        validator=validators.create_constant_value_validator(RoleTitle, True),
     )
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     body_ref = fields.ReferenceField(Body, auto_load=False)
@@ -565,7 +565,9 @@ class EventMinutesItem(Model):
     )
     index = fields.NumberField(required=True)
     decision = fields.TextField(
-        validator=validators.create_constant_value_validator(EventMinutesItemDecision)
+        validator=validators.create_constant_value_validator(
+            EventMinutesItemDecision, False
+        )
     )
     external_source_id = fields.TextField()
 
@@ -617,7 +619,9 @@ class MatterStatus(Model):
     event_minutes_item_ref = fields.ReferenceField(EventMinutesItem, auto_load=False)
     status = fields.TextField(
         required=True,
-        validator=validators.create_constant_value_validator(MatterStatusDecision),
+        validator=validators.create_constant_value_validator(
+            MatterStatusDecision, True
+        ),
     )
     update_datetime = fields.DateTime(required=True)
     external_source_id = fields.TextField()
@@ -709,7 +713,7 @@ class Vote(Model):
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     decision = fields.TextField(
         required=True,
-        validator=validators.create_constant_value_validator(VoteDecision),
+        validator=validators.create_constant_value_validator(VoteDecision, True),
     )
     in_majority = fields.BooleanField()
     external_source_id = fields.TextField()

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -190,7 +190,10 @@ class Role(Model):
     id = fields.IDField()
     title = fields.TextField(
         required=True,
-        validator=validators.create_constant_value_validator(RoleTitle, True),
+        validator=validators.create_constant_value_validator(
+            RoleTitle,
+            allow_none=False,
+        ),
     )
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     body_ref = fields.ReferenceField(Body, auto_load=False)
@@ -566,7 +569,8 @@ class EventMinutesItem(Model):
     index = fields.NumberField(required=True)
     decision = fields.TextField(
         validator=validators.create_constant_value_validator(
-            EventMinutesItemDecision, False
+            EventMinutesItemDecision,
+            allow_none=True,
         )
     )
     external_source_id = fields.TextField()
@@ -620,7 +624,8 @@ class MatterStatus(Model):
     status = fields.TextField(
         required=True,
         validator=validators.create_constant_value_validator(
-            MatterStatusDecision, True
+            MatterStatusDecision,
+            allow_none=False,
         ),
     )
     update_datetime = fields.DateTime(required=True)
@@ -713,7 +718,10 @@ class Vote(Model):
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     decision = fields.TextField(
         required=True,
-        validator=validators.create_constant_value_validator(VoteDecision, True),
+        validator=validators.create_constant_value_validator(
+            VoteDecision,
+            allow_none=False,
+        ),
     )
     in_majority = fields.BooleanField()
     external_source_id = fields.TextField()

--- a/cdp_backend/database/models.py
+++ b/cdp_backend/database/models.py
@@ -190,10 +190,7 @@ class Role(Model):
     id = fields.IDField()
     title = fields.TextField(
         required=True,
-        validator=validators.create_constant_value_validator(
-            RoleTitle,
-            allow_none=False,
-        ),
+        validator=validators.create_constant_value_validator(RoleTitle),
     )
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     body_ref = fields.ReferenceField(Body, auto_load=False)
@@ -568,10 +565,7 @@ class EventMinutesItem(Model):
     )
     index = fields.NumberField(required=True)
     decision = fields.TextField(
-        validator=validators.create_constant_value_validator(
-            EventMinutesItemDecision,
-            allow_none=True,
-        )
+        validator=validators.create_constant_value_validator(EventMinutesItemDecision)
     )
     external_source_id = fields.TextField()
 
@@ -623,10 +617,7 @@ class MatterStatus(Model):
     event_minutes_item_ref = fields.ReferenceField(EventMinutesItem, auto_load=False)
     status = fields.TextField(
         required=True,
-        validator=validators.create_constant_value_validator(
-            MatterStatusDecision,
-            allow_none=False,
-        ),
+        validator=validators.create_constant_value_validator(MatterStatusDecision),
     )
     update_datetime = fields.DateTime(required=True)
     external_source_id = fields.TextField()
@@ -718,10 +709,7 @@ class Vote(Model):
     person_ref = fields.ReferenceField(Person, required=True, auto_load=False)
     decision = fields.TextField(
         required=True,
-        validator=validators.create_constant_value_validator(
-            VoteDecision,
-            allow_none=False,
-        ),
+        validator=validators.create_constant_value_validator(VoteDecision),
     )
     in_majority = fields.BooleanField()
     external_source_id = fields.TextField()

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -157,7 +157,7 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
 
 
 def create_constant_value_validator(
-    constant_cls: Type, is_required: bool
+    constant_cls: Type, allow_none: bool
 ) -> Callable[[str], bool]:
     """
     Create a validator func that validates a value is one of the valid values.
@@ -166,13 +166,18 @@ def create_constant_value_validator(
     ----------
     constant_cls: Type
         The constant class that contains the valid values.
-    is_required: bool
-        Whether the value is required.
+    allow_none: bool
+        Whether to allow `None` as a valid value for this field.
 
     Returns
     -------
     validator_func: Callable[[str], bool]
         The validator func.
+
+    Notes
+    -----
+    If the field the created validation function is attached to is optional,
+    (i.e. required=True, is not set) `allow_none` should be set to True.
     """
 
     def is_valid(value: str) -> bool:
@@ -189,8 +194,10 @@ def create_constant_value_validator(
         status: bool
             The validation status.
         """
-        if value is None:
-            return not is_required
-        return value in get_all_class_attr_values(constant_cls)
+        allowed_attrs = get_all_class_attr_values(constant_cls)
+        if allow_none:
+            allowed_attrs.append(None)
+
+        return value in allowed_attrs
 
     return is_valid

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -156,7 +156,9 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
         return False
 
 
-def create_constant_value_validator(constant_cls: Type) -> Callable[[str], bool]:
+def create_constant_value_validator(
+    constant_cls: Type, is_required: bool
+) -> Callable[[str], bool]:
     """
     Create a validator func that validates a value is one of the valid values.
 
@@ -164,6 +166,8 @@ def create_constant_value_validator(constant_cls: Type) -> Callable[[str], bool]
     ----------
     constant_cls: Type
         The constant class that contains the valid values.
+    is_required: bool
+        Whether the value is required.
 
     Returns
     -------
@@ -185,6 +189,8 @@ def create_constant_value_validator(constant_cls: Type) -> Callable[[str], bool]
         status: bool
             The validation status.
         """
+        if value is None:
+            return not is_required
         return value in get_all_class_attr_values(constant_cls)
 
     return is_valid

--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -156,9 +156,7 @@ def resource_exists(uri: Optional[str], **kwargs: str) -> bool:
         return False
 
 
-def create_constant_value_validator(
-    constant_cls: Type, allow_none: bool
-) -> Callable[[str], bool]:
+def create_constant_value_validator(constant_cls: Type) -> Callable[[str], bool]:
     """
     Create a validator func that validates a value is one of the valid values.
 
@@ -166,8 +164,6 @@ def create_constant_value_validator(
     ----------
     constant_cls: Type
         The constant class that contains the valid values.
-    allow_none: bool
-        Whether to allow `None` as a valid value for this field.
 
     Returns
     -------
@@ -176,8 +172,10 @@ def create_constant_value_validator(
 
     Notes
     -----
-    If the field the created validation function is attached to is optional,
-    (i.e. required=True, is not set) `allow_none` should be set to True.
+    Will always allow `None` as a valid option.
+    To remove `None` as a viable input, set the database model field `required=True`.
+
+    See: https://github.com/CouncilDataProject/cdp-backend/pull/164
     """
 
     def is_valid(value: str) -> bool:
@@ -194,10 +192,6 @@ def create_constant_value_validator(
         status: bool
             The validation status.
         """
-        allowed_attrs = get_all_class_attr_values(constant_cls)
-        if allow_none:
-            allowed_attrs.append(None)
-
-        return value in allowed_attrs
+        return value is None or value in get_all_class_attr_values(constant_cls)
 
     return is_valid

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -1421,7 +1421,7 @@ def store_event_processing_results(
                             db_model=matter_status_db_model,
                             credentials_file=credentials_file,
                         )
-                    except FieldValidationFailed:
+                    except (FieldValidationFailed, RequiredField):
                         allowed_matter_decisions = (
                             constants_utils.get_all_class_attr_values(
                                 db_constants.MatterStatusDecision

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -136,12 +136,13 @@ def test_remote_resource_exists(
 @pytest.mark.parametrize(
     "decision, expected_result",
     [
+        (None, False),
         ("Approve", True),
         ("INVALID", False),
     ],
 )
 def test_vote_decision_is_valid(decision: str, expected_result: bool) -> None:
-    validator_func = validators.create_constant_value_validator(VoteDecision)
+    validator_func = validators.create_constant_value_validator(VoteDecision, True)
     actual_result = validator_func(decision)
     assert actual_result == expected_result
 
@@ -149,6 +150,7 @@ def test_vote_decision_is_valid(decision: str, expected_result: bool) -> None:
 @pytest.mark.parametrize(
     "decision, expected_result",
     [
+        (None, True),
         ("Passed", True),
         ("INVALID", False),
     ],
@@ -157,7 +159,7 @@ def test_event_minutes_item_decision_is_valid(
     decision: str, expected_result: bool
 ) -> None:
     validator_func = validators.create_constant_value_validator(
-        EventMinutesItemDecision
+        EventMinutesItemDecision, False
     )
     actual_result = validator_func(decision)
     assert actual_result == expected_result
@@ -166,12 +168,15 @@ def test_event_minutes_item_decision_is_valid(
 @pytest.mark.parametrize(
     "decision, expected_result",
     [
+        (None, False),
         ("Adopted", True),
         ("INVALID", False),
     ],
 )
 def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -> None:
-    validator_func = validators.create_constant_value_validator(MatterStatusDecision)
+    validator_func = validators.create_constant_value_validator(
+        MatterStatusDecision, True
+    )
     actual_result = validator_func(decision)
     assert actual_result == expected_result
 
@@ -179,11 +184,12 @@ def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -
 @pytest.mark.parametrize(
     "title, expected_result",
     [
+        (None, False),
         ("Councilmember", True),
         ("INVALID", False),
     ],
 )
 def test_role_title_is_valid(title: str, expected_result: bool) -> None:
-    validator_func = validators.create_constant_value_validator(RoleTitle)
+    validator_func = validators.create_constant_value_validator(RoleTitle, True)
     actual_result = validator_func(title)
     assert actual_result == expected_result

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -142,7 +142,10 @@ def test_remote_resource_exists(
     ],
 )
 def test_vote_decision_is_valid(decision: str, expected_result: bool) -> None:
-    validator_func = validators.create_constant_value_validator(VoteDecision, True)
+    validator_func = validators.create_constant_value_validator(
+        VoteDecision,
+        allow_none=False,
+    )
     actual_result = validator_func(decision)
     assert actual_result == expected_result
 
@@ -159,7 +162,8 @@ def test_event_minutes_item_decision_is_valid(
     decision: str, expected_result: bool
 ) -> None:
     validator_func = validators.create_constant_value_validator(
-        EventMinutesItemDecision, False
+        EventMinutesItemDecision,
+        allow_none=True,
     )
     actual_result = validator_func(decision)
     assert actual_result == expected_result
@@ -175,7 +179,8 @@ def test_event_minutes_item_decision_is_valid(
 )
 def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -> None:
     validator_func = validators.create_constant_value_validator(
-        MatterStatusDecision, True
+        MatterStatusDecision,
+        allow_none=False,
     )
     actual_result = validator_func(decision)
     assert actual_result == expected_result
@@ -190,6 +195,9 @@ def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -
     ],
 )
 def test_role_title_is_valid(title: str, expected_result: bool) -> None:
-    validator_func = validators.create_constant_value_validator(RoleTitle, True)
+    validator_func = validators.create_constant_value_validator(
+        RoleTitle,
+        allow_none=False,
+    )
     actual_result = validator_func(title)
     assert actual_result == expected_result

--- a/cdp_backend/tests/database/test_validators.py
+++ b/cdp_backend/tests/database/test_validators.py
@@ -136,16 +136,13 @@ def test_remote_resource_exists(
 @pytest.mark.parametrize(
     "decision, expected_result",
     [
-        (None, False),
+        (None, True),  # None always allowed in validator, rejected by model
         ("Approve", True),
         ("INVALID", False),
     ],
 )
 def test_vote_decision_is_valid(decision: str, expected_result: bool) -> None:
-    validator_func = validators.create_constant_value_validator(
-        VoteDecision,
-        allow_none=False,
-    )
+    validator_func = validators.create_constant_value_validator(VoteDecision)
     actual_result = validator_func(decision)
     assert actual_result == expected_result
 
@@ -153,7 +150,7 @@ def test_vote_decision_is_valid(decision: str, expected_result: bool) -> None:
 @pytest.mark.parametrize(
     "decision, expected_result",
     [
-        (None, True),
+        (None, True),  # None always allowed in validator, allowed by model
         ("Passed", True),
         ("INVALID", False),
     ],
@@ -163,7 +160,6 @@ def test_event_minutes_item_decision_is_valid(
 ) -> None:
     validator_func = validators.create_constant_value_validator(
         EventMinutesItemDecision,
-        allow_none=True,
     )
     actual_result = validator_func(decision)
     assert actual_result == expected_result
@@ -172,7 +168,7 @@ def test_event_minutes_item_decision_is_valid(
 @pytest.mark.parametrize(
     "decision, expected_result",
     [
-        (None, False),
+        (None, True),  # None always allowed in validator, rejected by model
         ("Adopted", True),
         ("INVALID", False),
     ],
@@ -180,7 +176,6 @@ def test_event_minutes_item_decision_is_valid(
 def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -> None:
     validator_func = validators.create_constant_value_validator(
         MatterStatusDecision,
-        allow_none=False,
     )
     actual_result = validator_func(decision)
     assert actual_result == expected_result
@@ -189,15 +184,12 @@ def test_matter_status_decision_is_valid(decision: str, expected_result: bool) -
 @pytest.mark.parametrize(
     "title, expected_result",
     [
-        (None, False),
+        (None, True),  # None always allowed in validator, rejected by model
         ("Councilmember", True),
         ("INVALID", False),
     ],
 )
 def test_role_title_is_valid(title: str, expected_result: bool) -> None:
-    validator_func = validators.create_constant_value_validator(
-        RoleTitle,
-        allow_none=False,
-    )
+    validator_func = validators.create_constant_value_validator(RoleTitle)
     actual_result = validator_func(title)
     assert actual_result == expected_result

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,10 @@ setup(
             "run_cdp_event_index=cdp_backend.bin.run_cdp_event_index:main",
             "search_cdp_events=cdp_backend.bin.search_cdp_events:main",
             "process_special_event=cdp_backend.bin.process_special_event:main",
-            "add_content_hash_to_sessions=cdp_backend.bin.add_content_hash_to_sessions:main",
+            (
+                "add_content_hash_to_sessions="
+                "cdp_backend.bin.add_content_hash_to_sessions:main"
+            ),
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
Reverts CouncilDataProject/cdp-backend#163

This PR created pipeline problems: https://github.com/CouncilDataProject/seattle-staging/runs/5219968602?check_suite_focus=true

Relevant part of the pipeline: https://github.com/CouncilDataProject/cdp-backend/blob/main/cdp_backend/pipeline/event_gather_pipeline.py#L1373

Logged warning:
```
[WARNING: event_gather_pipeline:1389 2022-02-16 17:04:24,396] Provided 'decision' is not an approved constant. Provided: 'None' Should be one of: ['Failed', 'Passed'] See: cdp_backend.database.constants.EventMinutesItemDecision. Creating EventMinutesItem without decision value.
```

DB model: https://github.com/CouncilDataProject/cdp-backend/blob/main/cdp_backend/database/models.py#L556

The only field on that db model with a validator is `decision` but it's not a required field, so why didn't this go through?

Because the validator _function_ doesn't allow `None` as an option. This is why I was so confused.

I am going to revert this change _and_ change the parameter name to be more explicit about what that parameter is doing. It isn't making it `required` or not, it is allowing `None` as a valid option.

I will also update tests and add more docs to make sure we don't forget this again :joy: 