### PR TITLE
bugfix/clean-pictograms-from-transcripts-before-indexing

### DIFF
--- a/cdp_backend/pipeline/event_index_pipeline.py
+++ b/cdp_backend/pipeline/event_index_pipeline.py
@@ -207,6 +207,7 @@ def read_transcripts_and_generate_grams(
                     cleaned_text=string_utils.clean_text(
                         sentence.text,
                         clean_stop_words=True,
+                        clean_emojis=True,
                     ),
                     n_grams=[],
                 )

--- a/cdp_backend/tests/utils/test_string_utils.py
+++ b/cdp_backend/tests/utils/test_string_utils.py
@@ -9,24 +9,84 @@ from cdp_backend.utils import string_utils
 
 
 @pytest.mark.parametrize(
-    "text, expected, clean_stop_words",
+    "text, expected, clean_stop_words, clean_emojis",
     [
-        ("hello and goodbye", "hello goodbye", True),
-        ("   \t\n   hello and to of a         goodbye         ", "hello goodbye", True),
-        ("hell'o    and   good-bye", "hello goodbye", True),
-        ("and", "", True),
-        ("hello and goodbye", "hello and goodbye", False),
+        (
+            "hello and goodbye",
+            "hello goodbye",
+            True,
+            True,
+        ),
+        (
+            "   \t\n   hello and to of a         goodbye         ",
+            "hello goodbye",
+            True,
+            True,
+        ),
+        (
+            "hell'o    and   good-bye",
+            "hello goodbye",
+            True,
+            True,
+        ),
+        (
+            "and",
+            "",
+            True,
+            True,
+        ),
+        (
+            "hello and goodbye",
+            "hello and goodbye",
+            False,
+            True,
+        ),
         (
             "   \t\n   hello and to of a         goodbye         ",
             "hello and to of a goodbye",
             False,
+            True,
         ),
-        ("hell'o    and   good-bye", "hello and goodbye", False),
-        ("and", "and", False),
+        (
+            "hell'o    and   good-bye",
+            "hello and goodbye",
+            False,
+            True,
+        ),
+        (
+            "and",
+            "and",
+            False,
+            True,
+        ),
+        (
+            "♪ Seattle channel music ♪",
+            "Seattle channel music",
+            False,
+            True,
+        ),
+        (
+            "\t\n    \t♪ Seattle channel music ♪",
+            "Seattle channel music",
+            False,
+            True,
+        ),
     ],
 )
-def test_clean_text(text: str, expected: str, clean_stop_words: bool) -> None:
-    assert string_utils.clean_text(text, clean_stop_words=clean_stop_words) == expected
+def test_clean_text(
+    text: str,
+    expected: str,
+    clean_stop_words: bool,
+    clean_emojis: bool,
+) -> None:
+    assert (
+        string_utils.clean_text(
+            text,
+            clean_stop_words=clean_stop_words,
+            clean_emojis=clean_emojis,
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/cdp_backend/utils/string_utils.py
+++ b/cdp_backend/utils/string_utils.py
@@ -107,10 +107,7 @@ def clean_text(
     # Remove gaps in string
     try:
         cleaned_doc = re.sub(r" {2,}", " ", cleaned_text)
-        if cleaned_doc[0] == " ":
-            cleaned_doc = cleaned_doc[1:]
-        if cleaned_doc[-1] == " ":
-            cleaned_doc = cleaned_doc[:-1]
+        cleaned_doc = cleaned_doc.strip()
 
     # IndexError occurs when the string was cleaned and it contained entirely stop
     # words or punctuation for some reason

--- a/cdp_backend/utils/string_utils.py
+++ b/cdp_backend/utils/string_utils.py
@@ -12,7 +12,38 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-def clean_text(text: str, clean_stop_words: bool = False) -> str:
+def remove_emojis(text: str) -> str:
+    """
+    Minor changes made from this answer on stackoverflow:
+    https://stackoverflow.com/a/58356570
+    """
+    emoj_patterns = re.compile(
+        "["
+        "\U0001F600-\U0001F64F"  # emoticons
+        "\U0001F300-\U0001F5FF"  # symbols & pictographs
+        "\U0001F680-\U0001F6FF"  # transport & map symbols
+        "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+        "\U00002702-\U000027B0"
+        "\U000024C2-\U0001F251"
+        "\U0001f926-\U0001f937"
+        "\u2600-\u2B55"
+        "\u200d"
+        "\u23cf"
+        "\u23e9"
+        "\u231a"
+        "\ufe0f"  # dingbats
+        "\u3030"
+        "]+",
+        re.UNICODE,
+    )
+    return re.sub(emoj_patterns, "", text)
+
+
+def clean_text(
+    text: str,
+    clean_stop_words: bool = False,
+    clean_emojis: bool = False,
+) -> str:
     """
     Clean text of common characters and extra formatting.
 
@@ -23,6 +54,9 @@ def clean_text(text: str, clean_stop_words: bool = False) -> str:
     clean_stop_words: bool
         Should English stop words be removed from the raw text or not.
         Default: False (do not remove stop words)
+    clean_emojis: bool
+        Should emojis, emoticons, pictograms, and other characters be removed.
+        Default: False (do not remove pictograms)
 
     Returns
     -------
@@ -57,18 +91,22 @@ def clean_text(text: str, clean_stop_words: bool = False) -> str:
             STOPWORDS = stopwords.words("english")
 
         joined_stopwords = "|".join(STOPWORDS)
-        cleaned_stopwords = re.sub(
+        cleaned_text = re.sub(
             r"\b(" + joined_stopwords + r")\b",
             "",
             cleaned_punctuation,
         )
     else:
         # Update for mypy typing
-        cleaned_stopwords = cleaned_punctuation
+        cleaned_text = cleaned_punctuation
+
+    # Remove pictograms
+    if clean_emojis:
+        cleaned_text = remove_emojis(cleaned_text)
 
     # Remove gaps in string
     try:
-        cleaned_doc = re.sub(r" {2,}", " ", cleaned_stopwords)
+        cleaned_doc = re.sub(r" {2,}", " ", cleaned_text)
         if cleaned_doc[0] == " ":
             cleaned_doc = cleaned_doc[1:]
         if cleaned_doc[-1] == " ":


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #151 

### Description of Changes

_Include a description of the proposed changes._

_Finally_ found time to fix this one. Can't believe the bug either.

Looks like a transcript from Seattle has a `♪` pictogram / emoticon in it...
[link -- start at 30:09 -- or search for `♪`](http://councildataproject.org/seattle-staging/#/events/c5d6d360b88d?s=0&t=1809)

This fixes the pipeline by adding a function to clean all common pictograms / emojis from the sentence before stemming and fuzzy matching for context spans.

Tested by running the pipeline and storing the index locally:
`run_cdp_event_index -n 1 --store_local --parallel ../configs-and-special-events/seattle.json`