### PR TITLE
bugfix/move-yt-dlp-import-to-within-youtube-copy-func

### DIFF
--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -11,7 +11,6 @@ from typing import Optional, Tuple, Union
 import aiohttp
 import fsspec
 from fsspec.core import url_to_fs
-from yt_dlp import YoutubeDL
 
 ###############################################################################
 
@@ -154,6 +153,8 @@ def youtube_copy(uri: str, dst: Path, overwrite: bool = False) -> str:
     dst: str
         The location of the downloaded file.
     """
+    from yt_dlp import YoutubeDL
+
     # dst = Path(str(dst) + ".mp4")
     dst = dst.with_suffix(".mp4")
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

_Include a description of the proposed changes._

Moves the `yt_dlp` import to within the `youtube_copy` function as otherwise, the dependency tree / install pattern breaks infra build: https://github.com/CouncilDataProject/portland/runs/5471195766?check_suite_focus=true