### PR TITLE
bugfix/fix-kwarg-issue-introduced-with-verify-false-resource-exists

### DIFF
--- a/cdp_backend/database/validators.py
+++ b/cdp_backend/database/validators.py
@@ -142,7 +142,7 @@ def resource_exists(uri: Optional[str], **kwargs: Any) -> bool:
     elif uri.startswith("http"):
         try:
             # Use HEAD request to check if remote resource exists
-            r = requests.head(uri, **kwargs)
+            r = requests.head(uri, verify=False)
 
             return r.status_code == requests.codes.ok
         except requests.exceptions.SSLError:

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -160,12 +160,7 @@ def create_event_gather_flow(
                 if session.caption_uri is not None:
                     # If the caption doesn't exist, remove the property
                     # This will result in Speech-to-Text being used instead
-                    #
-                    # The verify=False is passed to any http URIs
-                    # It was added because it's very common for SSL certs to be bad
-                    # See: https://github.com/CouncilDataProject/cdp-scrapers/pull/85
-                    # And: https://github.com/CouncilDataProject/seattle/runs/5957646032
-                    if not resource_exists(session.caption_uri, verify=False):
+                    if not resource_exists(session.caption_uri):
                         log.warning(
                             f"File not found using provided caption URI: "
                             f"'{session.caption_uri}'. "


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves bug introduced in #181

### Description of Changes

_Include a description of the proposed changes._

The prior PR and release introduced a bug as we were passing all kwargs to requests but we really just only need one and there is no reason to not use it all the time.

See this log for more details: https://github.com/CouncilDataProject/seattle/runs/5963347241?check_suite_focus=true