### PR TITLE
feature/add-resiliency-to-supporting-file-checking

### DIFF
--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -1458,7 +1458,6 @@ def store_event_processing_results(
                         except (
                             FieldValidationFailed,
                             ConnectionError,
-                            LookupError,
                         ) as e:
                             log.error(
                                 f"MatterFile ('{supporting_file.uri}') "

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -1442,6 +1442,7 @@ def store_event_processing_results(
                             f"SupportingFile ('{supporting_file.uri}') "
                             f"uri does not exist. Skipping. Error: {e}"
                         )
+                        continue
 
                     # Archive as matter file
                     if event_minutes_item.matter is not None:

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -1434,13 +1434,18 @@ def store_event_processing_results(
             # Add supporting files for matter and event minutes item
             if event_minutes_item.supporting_files is not None:
                 for supporting_file in event_minutes_item.supporting_files:
+                    try:
+                        file_uri = try_url(supporting_file.uri)
+                        supporting_file.uri = file_uri
+                    except LookupError as e:
+                        log.error(
+                            f"SupportingFile ('{supporting_file.uri}') "
+                            f"uri does not exist. Skipping. Error: {e}"
+                        )
 
                     # Archive as matter file
                     if event_minutes_item.matter is not None:
                         try:
-                            file_uri = try_url(supporting_file.uri)
-                            supporting_file.uri = file_uri
-
                             matter_file_db_model = db_functions.create_matter_file(
                                 matter_ref=matter_db_model,
                                 supporting_file=supporting_file,

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -1438,6 +1438,9 @@ def store_event_processing_results(
                     # Archive as matter file
                     if event_minutes_item.matter is not None:
                         try:
+                            file_uri = try_url(supporting_file.uri)
+                            supporting_file.uri = file_uri
+
                             matter_file_db_model = db_functions.create_matter_file(
                                 matter_ref=matter_db_model,
                                 supporting_file=supporting_file,
@@ -1447,7 +1450,11 @@ def store_event_processing_results(
                                 db_model=matter_file_db_model,
                                 credentials_file=credentials_file,
                             )
-                        except (FieldValidationFailed, ConnectionError) as e:
+                        except (
+                            FieldValidationFailed,
+                            ConnectionError,
+                            LookupError,
+                        ) as e:
                             log.error(
                                 f"MatterFile ('{supporting_file.uri}') "
                                 f"could not be archived. Skipping. Error: {e}"

--- a/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
+++ b/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
@@ -538,9 +538,7 @@ def test_store_event_processing_results(
     # externally either.
     mock_resource_copy.return_value = "doesnt-matter.ext"
 
-    with mock.patch(
-        "cdp_backend.database.validators.resource_exists"
-    ) as mock_resource_exists:
+    with mock.patch(f"{PIPELINE_PATH}.resource_exists") as mock_resource_exists:
         if fail_try_url:
             mock_resource_exists.side_effect = LookupError()
         else:

--- a/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
+++ b/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
@@ -45,7 +45,6 @@ from cdp_backend.pipeline.transcript_model import EXAMPLE_TRANSCRIPT, Transcript
 # great system stdlib :upsidedownface:
 
 PIPELINE_PATH = "cdp_backend.pipeline.event_gather_pipeline"
-DATABASE_PATH = "cdp_backend.database"
 VIDEO_CONTENT_HASH = "7490ea6cf56648d60a40dd334e46e5d7de0f31dde0c7ce4d85747896fdd2ab42"
 
 #############################################################################

--- a/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
+++ b/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
@@ -45,6 +45,7 @@ from cdp_backend.pipeline.transcript_model import EXAMPLE_TRANSCRIPT, Transcript
 # great system stdlib :upsidedownface:
 
 PIPELINE_PATH = "cdp_backend.pipeline.event_gather_pipeline"
+DATABASE_PATH = "cdp_backend.database"
 VIDEO_CONTENT_HASH = "7490ea6cf56648d60a40dd334e46e5d7de0f31dde0c7ce4d85747896fdd2ab42"
 
 #############################################################################
@@ -467,6 +468,7 @@ for i in range(6):
 @mock.patch(f"{PIPELINE_PATH}.fs_functions.upload_file")
 @mock.patch(f"{PIPELINE_PATH}.fs_functions.remove_local_file")
 @mock.patch(f"{PIPELINE_PATH}.db_functions.upload_db_model")
+@mock.patch(f"{DATABASE_PATH}.validators.resource_exists")
 @pytest.mark.parametrize(
     "event, session_processing_results, fail_file_uploads",
     [
@@ -520,6 +522,7 @@ def test_store_event_processing_results(
     mock_remove_local_file: MagicMock,
     mock_upload_file: MagicMock,
     mock_resource_copy: MagicMock,
+    mock_resource_exists: MagicMock,
     event: EventIngestionModel,
     session_processing_results: List[pipeline.SessionProcessingResult],
     fail_file_uploads: bool,
@@ -528,6 +531,8 @@ def test_store_event_processing_results(
     # But we aren't actually uploading so just make sure that we aren't downloading
     # externally either.
     mock_resource_copy.return_value = "doesnt-matter.ext"
+
+    mock_resource_exists.return_value = True
 
     # Set file upload side effect
     if fail_file_uploads:

--- a/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
+++ b/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
@@ -542,7 +542,7 @@ def test_store_event_processing_results(
         "cdp_backend.database.validators.resource_exists"
     ) as mock_resource_exists:
         if fail_try_url:
-            mock_resource_exists.side_effect = LookupError
+            mock_resource_exists.side_effect = LookupError()
         else:
             mock_resource_exists.return_value = True
 


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #179 

### Description of Changes

This PR adds a try_url call for the supporting_file.uri used before the creation / upload of a matter file (the try is done before these actions occur). If a LookupError is thrown, then perform a usual log. 
