### PR TITLE
feature/support-processing-m3u8-video-playlist-uris

### DIFF
--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -332,7 +332,7 @@ def convert_video_and_handle_host(
 
         # Update variable name for easier downstream typing
         video_filepath = mp4_filepath
-    
+
     # Check if original session video uri is a m3u8
     # We cant follow the normal coonvert video process from above
     # because the m3u8 looks to the URI for all the chunks

--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -332,6 +332,12 @@ def convert_video_and_handle_host(
 
         # Update variable name for easier downstream typing
         video_filepath = mp4_filepath
+    
+    # Check if original session video uri is a m3u8
+    # We cant follow the normal coonvert video process from above
+    # because the m3u8 looks to the URI for all the chunks
+    elif session.video_uri.endswith(".m3u8"):
+        cdp_will_host = True
 
     # Store if the original host isn't https
     elif not is_secure_uri(session.video_uri):

--- a/cdp_backend/tests/conftest.py
+++ b/cdp_backend/tests/conftest.py
@@ -32,6 +32,10 @@ EXAMPLE_VIDEO_HD_FILENAME = "example_video_large.mp4"
 EXAMPLE_YOUTUBE_VIDEO_EMBEDDED = "https://www.youtube.com/embed/XALBGkjkUPQ"
 EXAMPLE_YOUTUBE_VIDEO_PARAMETER = "https://www.youtube.com/watch?v=XALBGkjkUPQ"
 EXAMPLE_YOUTUBE_VIDEO_SHORT = "https://youtu.be/watch?v=XALBGkjkUPQ"
+EXAMPLE_M3U8_PLAYLIST_URI = (
+    "https://archive-stream.granicus.com/OnDemand/_definst_/mp4:oakland/"
+    "oakland_fa356edd-b6a3-4532-8118-3ce4881783f4.mp4/playlist.m3u8"
+)
 
 
 @pytest.fixture

--- a/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
+++ b/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
@@ -30,6 +30,7 @@ from cdp_backend.pipeline.mock_get_events import (
 )
 from cdp_backend.pipeline.pipeline_config import EventGatherPipelineConfig
 from cdp_backend.pipeline.transcript_model import EXAMPLE_TRANSCRIPT, Transcript
+
 from ..conftest import EXAMPLE_M3U8_PLAYLIST_URI
 
 #############################################################################

--- a/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
+++ b/cdp_backend/tests/pipeline/test_event_gather_pipeline.py
@@ -30,6 +30,7 @@ from cdp_backend.pipeline.mock_get_events import (
 )
 from cdp_backend.pipeline.pipeline_config import EventGatherPipelineConfig
 from cdp_backend.pipeline.transcript_model import EXAMPLE_TRANSCRIPT, Transcript
+from ..conftest import EXAMPLE_M3U8_PLAYLIST_URI
 
 #############################################################################
 
@@ -555,6 +556,9 @@ NON_EXISTENT_REMOTE_MINIMAL_EVENT.sessions[
     0
 ].video_uri = "s3://bucket/does-not-exist.txt"
 
+EXISTING_REMOTE_M3U8_MINIMAL_EVENT = deepcopy(EXAMPLE_MINIMAL_EVENT)
+EXISTING_REMOTE_M3U8_MINIMAL_EVENT.sessions[0].video_uri = EXAMPLE_M3U8_PLAYLIST_URI
+
 
 @mock.patch(f"{PIPELINE_PATH}.fs_functions.upload_file")
 @mock.patch(f"{PIPELINE_PATH}.fs_functions.get_open_url_for_gcs_file")
@@ -587,6 +591,12 @@ NON_EXISTENT_REMOTE_MINIMAL_EVENT.sessions[
             "example_video.mp4",
             "hosted-video.mp4",
         ),
+        (
+            "example_video.mp4",
+            deepcopy(EXISTING_REMOTE_M3U8_MINIMAL_EVENT.sessions[0]),
+            "example_video.mp4",
+            "hosted-video.mp4",
+        ),
     ],
 )
 def test_convert_video_and_handle_host(
@@ -599,7 +609,6 @@ def test_convert_video_and_handle_host(
     expected_filepath: str,
     expected_hosted_video_url: str,
 ) -> None:
-
     mock_upload_file.return_value = "file_store_uri"
     mock_generate_url.return_value = "hosted-video.mp4"
     mock_convert_video_to_mp4.return_value = expected_filepath

--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -21,6 +21,7 @@ from cdp_backend.utils.file_utils import (
 
 from .. import test_utils
 from ..conftest import (
+    EXAMPLE_M3U8_PLAYLIST_URI,
     EXAMPLE_MKV_VIDEO_FILENAME,
     EXAMPLE_VIDEO_FILENAME,
     EXAMPLE_VIDEO_HD_FILENAME,
@@ -239,19 +240,26 @@ def test_convert_video_to_mp4(
     reason="No internet connection",
 )
 @pytest.mark.parametrize(
-    "youtube_uri, expected",
+    "uri, expected",
     [
         (EXAMPLE_YOUTUBE_VIDEO_EMBEDDED, "XALBGkjkUPQ.mp4"),
         (EXAMPLE_YOUTUBE_VIDEO_PARAMETER, "XALBGkjkUPQ.mp4"),
         (EXAMPLE_YOUTUBE_VIDEO_SHORT, "XALBGkjkUPQ.mp4"),
+        (
+            EXAMPLE_M3U8_PLAYLIST_URI,
+            (
+                "9a9f4274874b62103bb93309fba58fef2dd34ef0b97409dc4ce5e365bf8bb13f-"
+                "playlist.mp4",
+            ),
+        ),
     ],
 )
-def test_youtube_downloader(
+def test_remote_resource_copy(
     resources_dir: Path,
-    youtube_uri: str,
+    uri: str,
     expected: str,
 ) -> None:
-    actual_uri = file_utils.resource_copy(youtube_uri, resources_dir, True)
+    actual_uri = file_utils.resource_copy(uri, resources_dir, True)
     expected_uri = str(resources_dir / expected)
     assert actual_uri == expected_uri
     assert Path(actual_uri).exists()

--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -257,7 +257,7 @@ def test_remote_resource_copy(
     if expected:
         expected_uri = str(resources_dir / expected)
         assert actual_uri == expected_uri
-    
+
     assert Path(actual_uri).exists()
     assert Path(actual_uri).is_file()
 

--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -245,23 +245,19 @@ def test_convert_video_to_mp4(
         (EXAMPLE_YOUTUBE_VIDEO_EMBEDDED, "XALBGkjkUPQ.mp4"),
         (EXAMPLE_YOUTUBE_VIDEO_PARAMETER, "XALBGkjkUPQ.mp4"),
         (EXAMPLE_YOUTUBE_VIDEO_SHORT, "XALBGkjkUPQ.mp4"),
-        (
-            EXAMPLE_M3U8_PLAYLIST_URI,
-            (
-                "9a9f4274874b62103bb93309fba58fef2dd34ef0b97409dc4ce5e365bf8bb13f-"
-                "playlist.mp4",
-            ),
-        ),
+        (EXAMPLE_M3U8_PLAYLIST_URI, None),
     ],
 )
 def test_remote_resource_copy(
     resources_dir: Path,
     uri: str,
-    expected: str,
+    expected: Optional[str],
 ) -> None:
     actual_uri = file_utils.resource_copy(uri, resources_dir, True)
-    expected_uri = str(resources_dir / expected)
-    assert actual_uri == expected_uri
+    if expected:
+        expected_uri = str(resources_dir / expected)
+        assert actual_uri == expected_uri
+    
     assert Path(actual_uri).exists()
     assert Path(actual_uri).is_file()
 

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -7,6 +7,7 @@ import random
 from hashlib import sha256
 from pathlib import Path
 from typing import Optional, Tuple, Union
+from uuid import uuid4
 
 import fsspec
 import requests
@@ -116,12 +117,11 @@ def resource_copy(
         if uri.endswith(".m3u8"):
             import m3u8_To_MP4
 
-            # We add a hash of the uri to the front of the filename because m3u8 files
+            # We add a uuid4 to the front of the filename because m3u8 files
             # are usually simply called playlist.m3u8 -- the result will be
-            # f"{hash}-{name}"
-            uri_hash = sha256(uri.encode("utf-8")).hexdigest()
+            # f"{uuid}-{name}"
             mp4_name = dst.with_suffix(".mp4").name
-            save_name = f"{uri_hash}-{mp4_name}"
+            save_name = f"{uuid4()}-{mp4_name}"
 
             # Reset dst
             dst = dst.parent / save_name

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -7,6 +7,7 @@ import random
 from hashlib import sha256
 from pathlib import Path
 from typing import Optional, Tuple, Union
+from uuid import uuid4
 
 import fsspec
 import requests
@@ -112,6 +113,26 @@ def resource_copy(
     try:
         if uri.find("youtube.com") >= 0 or uri.find("youtu.be") >= 0:
             return youtube_copy(uri, dst, overwrite)
+
+        if uri.endswith(".m3u8"):
+            import m3u8_To_MP4
+            # We add a uuid4 to the front of the filename because m3u8 files
+            # are usually simply called playlist.m3u8
+            # the result will be
+            # f"{uuid4}-{name}"
+            mp4_name = dst.with_suffix(".mp4").name
+            save_name = f"{uuid4()}-{mp4_name}"
+
+            # Reset dst
+            dst = dst.parent / save_name
+
+            # Download and convert
+            m3u8_To_MP4.download(
+                uri,
+                mp4_file_dir=dst.parent,
+                mp4_file_name=save_name,
+            )
+            return dst
 
         # Set custom timeout for http resources
         if uri.startswith("http"):

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -7,7 +7,6 @@ import random
 from hashlib import sha256
 from pathlib import Path
 from typing import Optional, Tuple, Union
-from uuid import uuid4
 
 import fsspec
 import requests
@@ -116,12 +115,13 @@ def resource_copy(
 
         if uri.endswith(".m3u8"):
             import m3u8_To_MP4
-            # We add a uuid4 to the front of the filename because m3u8 files
-            # are usually simply called playlist.m3u8
-            # the result will be
-            # f"{uuid4}-{name}"
+
+            # We add a hash of the uri to the front of the filename because m3u8 files
+            # are usually simply called playlist.m3u8 -- the result will be
+            # f"{hash}-{name}"
+            uri_hash = sha256(uri.encode("utf-8")).hexdigest()
             mp4_name = dst.with_suffix(".mp4").name
-            save_name = f"{uuid4()}-{mp4_name}"
+            save_name = f"{uri_hash}-{mp4_name}"
 
             # Reset dst
             dst = dst.parent / save_name
@@ -132,7 +132,7 @@ def resource_copy(
                 mp4_file_dir=dst.parent,
                 mp4_file_name=save_name,
             )
-            return dst
+            return str(dst)
 
         # Set custom timeout for http resources
         if uri.startswith("http"):

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ pipeline_requirements = [
     "graphviz~=0.16",
     "imageio~=2.18",
     "imageio-ffmpeg~=0.4",
+    "m3u8-To-MP4~=0.1",
     "nltk~=3.6",
     "pandas~=1.0",
     "prefect~=1.2",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

https://github.com/CouncilDataProject/cdp-scrapers/pull/96#issuecomment-1114325009

### Description of Changes

_Include a description of the proposed changes._

Allows processing of m3u8 URIs.

What will happen is during `resource_copy` we will download and convert the m3u8 playlist to an mp4. Then during determining the video host, we check the original session video uri and see if it ends with `".m3u8"` and if so, we host the already converted and saved locally m3u8 file.