### PR TITLE
bugfix/create-firestore-indexes-one-after-another

### DIFF
--- a/cdp_backend/infrastructure/cdp_stack.py
+++ b/cdp_backend/infrastructure/cdp_stack.py
@@ -211,7 +211,7 @@ class CDPStack(pulumi.ComponentResource):
                     depends_on = [prior_index]
 
                 # Create
-                firestore.Index(
+                prior_index = firestore.Index(
                     fq_idx_set_name,
                     project=self.gcp_project_id,
                     database_id="(default)",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves https://github.com/pulumi/pulumi-google-native/issues/528

### Description of Changes

_Include a description of the proposed changes._

Indexes are now going to be created one after another, not in parallel. This takes much longer but works.