### PR TITLE
feature/filter-out-invalid-captions

### DIFF
--- a/cdp_backend/pipeline/event_gather_pipeline.py
+++ b/cdp_backend/pipeline/event_gather_pipeline.py
@@ -160,7 +160,11 @@ def create_event_gather_flow(
                 if session.caption_uri is not None:
                     # If the caption doesn't exist, remove the property
                     # This will result in Speech-to-Text being used instead
-                    if not resource_exists(session.caption_uri):
+                    if not resource_exists(
+                        session.caption_uri
+                    ) or not file_utils.caption_is_valid(
+                        tmp_video_filepath, session.caption_uri
+                    ):
                         log.warning(
                             f"File not found using provided caption URI: "
                             f"'{session.caption_uri}'. "

--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -342,16 +342,14 @@ def test_caption_is_valid(
     is_resource: bool,
     expected: bool,
 ) -> None:
-    def path_as_str(path: Path) -> str:
-        return str(bytes(path), encoding="utf-8")
-
     with TemporaryDirectory() as dir_path:
-        temp_video = path_as_str(Path(dir_path) / f"caption-test-{end_time}.mp4")
-        ffmpeg.input(path_as_str(resources_dir / video_uri)).output(
+        temp_video = str(Path(dir_path) / f"caption-test-{end_time}.mp4")
+        ffmpeg.input(str(resources_dir / video_uri)).output(
             temp_video, codec="copy", t=end_time
         ).run(overwrite_output=True)
 
         if is_resource:
-            caption_uri = path_as_str(resources_dir / caption_uri)
+            caption_uri = str(resources_dir / caption_uri)
 
+        print(temp_video)
         assert caption_is_valid(temp_video, caption_uri) == expected

--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -340,15 +340,16 @@ def test_caption_is_valid(
     is_resource: bool,
     expected: bool,
 ) -> None:
+    def path_as_str(path: Path) -> str:
+        return str(bytes(path), encoding="utf-8")
+
     with TemporaryDirectory() as dir_path:
-        temp_video = str(
-            bytes(Path(dir_path) / f"caption-test-{end_time}.mp4"), encoding="utf-8"
-        )
-        ffmpeg.input(str(bytes(resources_dir / video_uri), encoding="utf-8")).output(
+        temp_video = path_as_str(Path(dir_path) / f"caption-test-{end_time}.mp4")
+        ffmpeg.input(path_as_str(resources_dir / video_uri)).output(
             temp_video, codec="copy", t=end_time
         ).run(overwrite_output=True)
 
         if is_resource:
-            caption_uri = str(bytes(resources_dir / caption_uri), encoding="utf-8")
+            caption_uri = path_as_str(resources_dir / caption_uri)
 
         assert caption_is_valid(temp_video, caption_uri) == expected

--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -320,13 +320,15 @@ def test_clip_and_reformat_video(
 @pytest.mark.parametrize(
     "video_uri, caption_uri, end_time, is_resource, expected",
     [
+        # the video is about 3 minutes and boston_captions.vtt is about 1 minute
         (EXAMPLE_VIDEO_FILENAME, "boston_captions.vtt", 120, True, False),
         (EXAMPLE_VIDEO_FILENAME, "boston_captions.vtt", 60, True, True),
         (
             EXAMPLE_VIDEO_FILENAME,
+            # about 30 seconds
             "https://gist.github.com/dphoria/d3f35b5509b784ccd14b7efdc67df752/raw/"
             "c18fc459c62ff7530536ba19d08021682627c18a/sample.vtt",
-            27,
+            30,
             False,
             True,
         ),

--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -317,23 +317,24 @@ def test_clip_and_reformat_video(
 
 
 @pytest.mark.parametrize(
-    "video_uri, caption_uri, end_time, expected",
+    "video_uri, caption_uri, end_time, is_resource, expected",
     [
-        (EXAMPLE_VIDEO_FILENAME, "boston_captions.vtt", 120, False),
-        (EXAMPLE_VIDEO_FILENAME, "boston_captions.vtt", 60, True),
+        (EXAMPLE_VIDEO_FILENAME, "boston_captions.vtt", 120, True, False),
+        (EXAMPLE_VIDEO_FILENAME, "boston_captions.vtt", 60, True, True),
+        (EXAMPLE_VIDEO_FILENAME, "https://gist.github.com/dphoria/d3f35b5509b784ccd14b7efdc67df752/raw/c18fc459c62ff7530536ba19d08021682627c18a/sample.vtt", 27, False, True),
     ],
 )
 def test_caption_is_valid(
-    resources_dir: Path, video_uri: str, caption_uri: str, end_time: int, expected: bool
+    resources_dir: Path, video_uri: str, caption_uri: str, end_time: int, is_resource: bool, expected: bool
 ) -> None:
     temp_video = "caption-test.mp4"
     ffmpeg.input(str(bytes(resources_dir / video_uri), encoding="utf-8")).output(
         temp_video, codec="copy", t=end_time
     ).run(overwrite_output=True)
 
-    valid = caption_is_valid(
-        temp_video,
-        str(bytes(resources_dir / caption_uri), encoding="utf-8"),
-    )
+    if is_resource:
+        caption_uri = str(bytes(resources_dir / caption_uri), encoding="utf-8")
+
+    valid = caption_is_valid(temp_video, caption_uri)
     os.remove(temp_video)
     assert valid == expected


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #213 

### Description of Changes

In `create_event_gather_flow()`, in addition to calling `resource_exists()` for `session.caption_uri`, further validate the caption file by comparing its length against the video at `session.video_uri`. Reject, i.e. just do speech-to-text, if their lengths differ by more than 20%.
