### PR TITLE
bugfix/index_chunks_not_updated

### DIFF
--- a/cdp_backend/file_store/functions.py
+++ b/cdp_backend/file_store/functions.py
@@ -67,6 +67,7 @@ def upload_file(
     filepath: str,
     save_name: Optional[str] = None,
     remove_local: bool = False,
+    overwrite: bool = False,
 ) -> str:
     """
     Uploads a file to a Google Cloud file store bucket.
@@ -88,6 +89,9 @@ def upload_file(
         The name to save the file as in the file store.
     remove_local: bool
         If True, remove the local file upon successful upload.
+    overwrite: bool
+        Boolean value indicating whether or not to overwrite the remote resource with
+        the same name if it already exists.
 
     Returns
     -------
@@ -107,7 +111,7 @@ def upload_file(
     uri = get_file_uri(bucket, save_name, credentials_file)
 
     # Return existing uri and remove local copy if desired
-    if uri:
+    if uri and not overwrite:
         if remove_local:
             remove_local_file(resolved_filepath)
 

--- a/cdp_backend/pipeline/generate_event_index_pipeline.py
+++ b/cdp_backend/pipeline/generate_event_index_pipeline.py
@@ -383,6 +383,7 @@ def chunk_index(
                 bucket=bucket_name,
                 filepath=str(local_chunk_path),
                 save_name=f"{REMOTE_INDEX_CHUNK_DIR}/{save_filename}",
+                overwrite=True,
             )
 
 

--- a/cdp_backend/tests/file_store/test_functions.py
+++ b/cdp_backend/tests/file_store/test_functions.py
@@ -17,7 +17,7 @@ FILENAME = "file.txt"
 BUCKET = "bucket"
 FILEPATH = "fake/path/" + FILENAME
 SAVE_NAME = "fakeSaveName"
-EXISTING_FILE_URI = "gs://bucket/existing_file.json"
+EXISTING_FILE_URI = "gs://bucket/" + SAVE_NAME
 GCS_FILE_URI = functions.GCS_URI.format(bucket=BUCKET, filename=FILENAME)
 
 ###############################################################################
@@ -56,12 +56,68 @@ def test_get_file_uri(
 
 
 @pytest.mark.parametrize(
-    "bucket, filepath, save_name, remove_local, existing_file_uri, expected",
+    "bucket, filepath, save_name, remove_local, overwrite, existing_file_uri, expected",
     [
-        (BUCKET, FILEPATH, SAVE_NAME, True, EXISTING_FILE_URI, EXISTING_FILE_URI),
-        (BUCKET, FILEPATH, SAVE_NAME, False, EXISTING_FILE_URI, EXISTING_FILE_URI),
-        (BUCKET, FILEPATH, None, False, None, GCS_FILE_URI),
-        (BUCKET, FILEPATH, None, True, None, GCS_FILE_URI),
+        (
+            BUCKET,
+            FILEPATH,
+            SAVE_NAME,
+            True,
+            True,
+            EXISTING_FILE_URI,
+            EXISTING_FILE_URI,
+        ),
+        (
+            BUCKET,
+            FILEPATH,
+            SAVE_NAME,
+            True,
+            True,
+            None,
+            EXISTING_FILE_URI,
+        ),
+        (
+            BUCKET,
+            FILEPATH,
+            SAVE_NAME,
+            True,
+            False,
+            EXISTING_FILE_URI,
+            EXISTING_FILE_URI,
+        ),
+        (
+            BUCKET,
+            FILEPATH,
+            SAVE_NAME,
+            False,
+            True,
+            EXISTING_FILE_URI,
+            EXISTING_FILE_URI,
+        ),
+        (
+            BUCKET,
+            FILEPATH,
+            SAVE_NAME,
+            False,
+            True,
+            None,
+            EXISTING_FILE_URI,
+        ),
+        (
+            BUCKET,
+            FILEPATH,
+            SAVE_NAME,
+            False,
+            False,
+            EXISTING_FILE_URI,
+            EXISTING_FILE_URI,
+        ),
+        (BUCKET, FILEPATH, None, False, True, GCS_FILE_URI, GCS_FILE_URI),
+        (BUCKET, FILEPATH, None, False, True, None, GCS_FILE_URI),
+        (BUCKET, FILEPATH, None, False, False, None, GCS_FILE_URI),
+        (BUCKET, FILEPATH, None, True, True, GCS_FILE_URI, GCS_FILE_URI),
+        (BUCKET, FILEPATH, None, True, True, None, GCS_FILE_URI),
+        (BUCKET, FILEPATH, None, True, False, None, GCS_FILE_URI),
     ],
 )
 def test_upload_file(
@@ -69,6 +125,7 @@ def test_upload_file(
     filepath: str,
     save_name: Optional[str],
     remove_local: bool,
+    overwrite: bool,
     existing_file_uri: str,
     expected: str,
 ) -> None:
@@ -82,7 +139,12 @@ def test_upload_file(
                     mock_path.return_value.name = FILENAME
 
                     assert expected == functions.upload_file(
-                        "path/to/creds", bucket, filepath, save_name, remove_local
+                        "path/to/creds",
+                        bucket,
+                        filepath,
+                        save_name,
+                        remove_local,
+                        overwrite,
                     )
 
 


### PR DESCRIPTION
### Link to Relevant Issue

This PR relates to this discussion on Slack: 

https://councildataproject.slack.com/archives/CMMNC8Y7P/p1664648853737539?thread_ts=1663622963.782599&cid=CMMNC8Y7P

### Description of Changes

For the Asheville CDP instance, we encountered an issue where our event index / search was not being updated for new events. After investigating, I realized that the GCS index-chunks files were not being updates. 

The generate_event_index_pipeline.py routine calls chunk_index, which in turn calls fs_functions.upload_file.

The upload_file function checks if the file exists on the remote resource - if so, it just returns the existing URI. As a result, there is no ability to overwrite existing index-chunk files. 

https://github.com/CouncilDataProject/cdp-backend/blob/e8835080d2f563f850a346baba17f26da67fe822/cdp_backend/file_store/functions.py#L64

This PR adds an optional parameter, overwrite to the upload_file function. It modifies generate_event_index_pipeline.py to set overrwrite=true when upload_file is called. 

I attempted to add tests for this modification in behavior, included cases to confirm the same URI is returned if the file does / does not exist and overwrite=True. 

In test_functions.py, I modified the *EXISTING_FILE_URI* variable - I felt that it indicated a URI that was not in alignment with what the upload_file function should be expected to produce. If the given SAVE_NAME is included in the call to upload_file, the EXISTING_FILE_URI would include that as part of the URI. 

I'm not super familiar with how the mock.patch calls work - but I believe they are changing the behavior of "cdp_backend.file_store.functions.get_file_uri" in a way that caused the tests to pass previously - though they should have failed. For example, previously, EXISTING_FILE_URI = "gs://bucket/test_file.json". However, the test parameters indicated that there was an existing file with URI = EXISTING_FILE_URI, but the requested upload was for SAVE_NAME ("fakeSaveName"). The resulting URI should be "gs://bucket/fakeSaveName"
 
 I'm not completely familiar with writing tests in Python — any review or feedback is appreciated! 