### PR TITLE
Remove Unneccessary Re-Encode If Video Is Already H264

### DIFF
--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -389,33 +389,38 @@ def test_clip_and_reformat_video(
 
 
 @pytest.mark.parametrize(
-    "videofile_path, codec_type, codec_name, expected",
+    "video_filepath, output_format, codec_type, codec_name, expected",
     [
-        (Path("video.mp4"), "video", "h264", True),
-        (Path("video.MP4"), "video", "h264", True),
-        (Path("video.mp4"), "video", "mpeg4", False),
-        (Path("video.mkv"), "video", "h264", False),
-        (Path("video.MKV"), "video", "h264", False),
-        (Path("video.avi"), "video", "mpeg4", False),
-        (Path("video.avi"), "audio", "mp3", False),
+        (Path("video.mp4"), "mp4", "video", "h264", True),
+        (Path("video.MP4"), "mp4", "video", "h264", True),
+        (Path("video.mp4"), "mp4", "video", "mpeg4", False),
+        (Path("video.mkv"), "mp4", "video", "h264", False),
+        (Path("video.MKV"), "mp4", "video", "h264", False),
+        (Path("video.avi"), "mp4", "video", "mpeg4", False),
+        (Path("video.avi"), "mp4", "audio", "mp3", False),
+        (Path("video.mp4"), "mp3", "video", "h264", False),
     ],
 )
 def test_should_copy_video(
-    videofile_path: Path, codec_type: str, codec_name: str, expected: bool
+    video_filepath: Path,
+    output_format: str,
+    codec_type: str,
+    codec_name: str,
+    expected: bool,
 ) -> None:
     with mock.patch("ffmpeg.probe") as ffmpeg_probe:
         ffmpeg_probe.return_value = {
             "streams": [{"codec_type": codec_type, "codec_name": codec_name}]
         }
         if expected:
-            assert file_utils.should_copy_video(videofile_path)
+            assert file_utils.should_copy_video(video_filepath, output_format)
         else:
-            assert not file_utils.should_copy_video(videofile_path)
+            assert not file_utils.should_copy_video(video_filepath, output_format)
 
 
 def test_should_copy_video_exception() -> None:
     with mock.patch("ffmpeg.probe") as ffmpeg_probe:
         import ffmpeg
 
-        ffmpeg_probe.side_effect = ffmpeg.Error("boom", "boom", "boom")
-        assert not file_utils.should_copy_video(Path("video.mp4"))
+        ffmpeg_probe.side_effect = ffmpeg.Error("ffprobe", "nothing", "nothing good")
+        assert not file_utils.should_copy_video(Path("unknown_video.mp4"))

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -721,6 +721,10 @@ def clip_and_reformat_video(
 
     output_kwargs = {"format": output_format}
     if should_copy_video(video_filepath, output_format):
+        log.info(
+            f"Video {video_filepath} is already h264, "
+            "it will be clipped and copied instead of clipped and re-encoded."
+        )
         output_kwargs["codec"] = "copy"
 
     try:

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -721,9 +721,6 @@ def clip_and_reformat_video(
 
     out_args = {"format": output_format}
 
-    if should_copy_video(video_filepath):
-        out_args["codec"] = "copy"
-
     try:
         ffmpeg_stdout, ffmpeg_stderr = (
             ffmpeg.input(
@@ -731,7 +728,12 @@ def clip_and_reformat_video(
                 ss=start_time or "0",
                 to=end_time or "99:59:59",
             )
-            .output(filename=str(output_path), out_args=out_args)
+            .output(
+                filename=str(output_path),
+                **dict(out_args, codec="copy")
+                if should_copy_video(video_filepath)
+                else out_args,
+            )
             .run(capture_stdout=True, capture_stderr=True)
         )
     except ffmpeg._run.Error as e:

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -719,6 +719,13 @@ def clip_and_reformat_video(
 
     output_path = output_path or append_to_stem(video_filepath, "_clipped")
 
+    out_args = {
+        'format': output_format
+    }
+
+    if should_copy_video(video_filepath):
+        out_args['codec'] = 'copy'
+
     try:
         ffmpeg_stdout, ffmpeg_stderr = (
             ffmpeg.input(
@@ -726,7 +733,7 @@ def clip_and_reformat_video(
                 ss=start_time or "0",
                 to=end_time or "99:59:59",
             )
-            .output(filename=str(output_path), format=output_format)
+            .output(filename=str(output_path), out_args=out_args)
             .run(capture_stdout=True, capture_stderr=True)
         )
     except ffmpeg._run.Error as e:
@@ -739,3 +746,36 @@ def clip_and_reformat_video(
         log.error(ffmpeg_stderr)
 
     return output_path
+
+def should_copy_video(video_filepath: Path) -> bool:
+    """
+    Check if the video should be copied or re-encoded.
+
+    Parameters
+    ----------
+    video_filepath: Path
+        The filepath of the video under scrutiny.
+
+    Returns
+    -------
+    bool:
+        True if the video should be copied, False if it should be re-encoded.
+    """
+
+    if video_filepath.suffix.lower() != '.mp4':
+        return False
+
+    import ffmpeg
+    try:
+        streams = ffmpeg.probe(video_filepath)['streams']
+    except ffmpeg.Error as e:
+        log.warning(f"Failed to probe {video_filepath}, unable to determine if video should be copied or re-encoded. Falling back to re-encoding. ffmpeg error: {e.stderr}")
+        return False
+
+    should_copy_video = False
+    for stream in streams:
+        if stream['codec_type'] == 'video' and stream['codec_name'] == 'h264':
+            should_copy_video = True
+            break
+
+    return should_copy_video

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -719,12 +719,10 @@ def clip_and_reformat_video(
 
     output_path = output_path or append_to_stem(video_filepath, "_clipped")
 
-    out_args = {
-        'format': output_format
-    }
+    out_args = {"format": output_format}
 
     if should_copy_video(video_filepath):
-        out_args['codec'] = 'copy'
+        out_args["codec"] = "copy"
 
     try:
         ffmpeg_stdout, ffmpeg_stderr = (
@@ -747,6 +745,7 @@ def clip_and_reformat_video(
 
     return output_path
 
+
 def should_copy_video(video_filepath: Path) -> bool:
     """
     Check if the video should be copied or re-encoded.
@@ -762,19 +761,22 @@ def should_copy_video(video_filepath: Path) -> bool:
         True if the video should be copied, False if it should be re-encoded.
     """
 
-    if video_filepath.suffix.lower() != '.mp4':
+    if video_filepath.suffix.lower() != ".mp4":
         return False
 
     import ffmpeg
+
     try:
-        streams = ffmpeg.probe(video_filepath)['streams']
+        streams = ffmpeg.probe(video_filepath)["streams"]
     except ffmpeg.Error as e:
-        log.warning(f"Failed to probe {video_filepath}, unable to determine if video should be copied or re-encoded. Falling back to re-encoding. ffmpeg error: {e.stderr}")
+        log.warning(
+            f"Failed to probe {video_filepath}, unable to determine if video should be copied or re-encoded. Falling back to re-encoding. ffmpeg error: {e.stderr}"
+        )
         return False
 
     should_copy_video = False
     for stream in streams:
-        if stream['codec_type'] == 'video' and stream['codec_name'] == 'h264':
+        if stream["codec_type"] == "video" and stream["codec_name"] == "h264":
             should_copy_video = True
             break
 

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -760,7 +760,6 @@ def should_copy_video(video_filepath: Path) -> bool:
     bool:
         True if the video should be copied, False if it should be re-encoded.
     """
-
     if video_filepath.suffix.lower() != ".mp4":
         return False
 
@@ -770,7 +769,9 @@ def should_copy_video(video_filepath: Path) -> bool:
         streams = ffmpeg.probe(video_filepath)["streams"]
     except ffmpeg.Error as e:
         log.warning(
-            f"Failed to probe {video_filepath}, unable to determine if video should be copied or re-encoded. Falling back to re-encoding. ffmpeg error: {e.stderr}"
+            f"Failed to probe {video_filepath}. "
+            "Unable to determine if video should be copied or re-encoded."
+            f"Falling back to re-encoding. ffmpeg error: {e.stderr}"
         )
         return False
 


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #233 

### Description of Changes

Context: In [clip_and_reformat_video](https://github.com/CouncilDataProject/cdp-backend/blob/a79be80f69ffff8530115bba1ddc71ca592579aa/cdp_backend/utils/file_utils.py#L689) if the video is already mp4/h264 encoded, the ffmpeg stream will re-encode the clipped portion (if clipping is present) or in the worst case re-encode the whole video _again_ as h264.

This PR modifies the behavior of clip_and_reformat_video such that…

- The video at video_filepath has a .mp4 extension, and
- The desired output format is mp4, and
- The video at video_filepath has a video stream with a codec of h264

… then ffmpeg stream will use ffmpeg's [StreamCopy codec](https://ffmpeg.org/ffmpeg.html#Stream-copy) to copy the video/audio streams to the output file instead of decoding and encoding the input and output streams respectively. According to ffmpeg: "it is very fast and there is no quality loss."

This change should result in a significant decrease in Event Gather pipeline runtime for data sources that already provide mp4/h264 encoded videos.