### PR TITLE
Use requests stream and shutil.copyfileobj to constrain memory usage during resource copy

### DIFF
--- a/cdp_backend/tests/utils/test_file_utils.py
+++ b/cdp_backend/tests/utils/test_file_utils.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import imageio
 import pytest
+import requests_mock
 
 from cdp_backend.utils import file_utils
 from cdp_backend.utils.file_utils import (
@@ -112,6 +113,19 @@ def test_get_media_type(uri: str, expected_result: str | None) -> None:
 def test_resource_copy(tmpdir, example_video: Path) -> None:  # type: ignore
     save_path = tmpdir / EXAMPLE_VIDEO_FILENAME
     resource_copy(str(example_video), save_path)
+
+
+def test_resource_copy_https(tmpdir, example_video: Path) -> None:  # type: ignore
+    with requests_mock.Mocker() as mock:
+        example_video_file = imageio.read(example_video)
+        mock.get("https://example.com/example_video.mp4", body=example_video_file)
+        dest = tmpdir / "example_video.mp4"
+        saved_path = resource_copy(
+            "https://example.com/example_video.mp4",
+            dest,
+        )
+        assert saved_path == dest
+        example_video_file.close()
 
 
 # Type ignore because changing tmpdir typing

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -238,7 +238,9 @@ def resource_copy(  # noqa: C901
             with requests.get(uri, stream=True, verify=False, timeout=1800) as r:
                 r.raise_for_status()
                 with open(dst, "wb") as open_dst:
-                    shutil.copyfileobj(r.raw, open_dst, length=64 * 1024 * 1024) # 64MB chunks
+                    shutil.copyfileobj(
+                        r.raw, open_dst, length=64 * 1024 * 1024  # 64MB chunks
+                    )
 
         else:
             # TODO: Add explicit use of GCS credentials until public read is fixed

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -6,9 +6,9 @@ import logging
 import math
 import random
 import re
+import shutil
 from hashlib import sha256
 from pathlib import Path
-import shutil
 from uuid import uuid4
 
 import fireo

--- a/cdp_backend/utils/file_utils.py
+++ b/cdp_backend/utils/file_utils.py
@@ -8,6 +8,7 @@ import random
 import re
 from hashlib import sha256
 from pathlib import Path
+import shutil
 from uuid import uuid4
 
 import fireo
@@ -225,21 +226,19 @@ def resource_copy(  # noqa: C901
             )
             return str(dst)
 
-        # Set custom timeout for http resources
+        # Common case: http(s) URI
         if uri.startswith("http"):
             # The verify=False is passed to any http URIs
             # It was added because it's very common for SSL certs to be bad
             # See: https://github.com/CouncilDataProject/cdp-scrapers/pull/85
             # And: https://github.com/CouncilDataProject/seattle/runs/5957646032
 
-            with open(dst, "wb") as open_dst:
-                open_dst.write(
-                    requests.get(
-                        uri,
-                        verify=False,
-                        timeout=1800,
-                    ).content
-                )
+            # Use stream=True to avoid downloading the entire file into memory
+            # See: https://github.com/CouncilDataProject/cdp-backend/issues/235
+            with requests.get(uri, stream=True, verify=False, timeout=1800) as r:
+                r.raise_for_status()
+                with open(dst, "wb") as open_dst:
+                    shutil.copyfileobj(r.raw, open_dst, length=64 * 1024 * 1024) # 64MB chunks
 
         else:
             # TODO: Add explicit use of GCS credentials until public read is fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ test = [
   # Extras
   "networkx>=2.5",
   "pydot>=1.4",
+  "requests-mock>=1.10.0"
 ]
 docs = [
   # Sphinx + Doc Gen + Styling


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #235

### Description of Changes

- When copying resources from a remote origin over HTTP(S) prefer to stream the response body and copy chunks into the destination file insead of loading the entire file into memory first before writing.
- Before the change, running resource_copy("uri") in python REPL would use unbounded rss (up to file size). After the change, running the same in python REPL uses ~300M rss.