### PR TITLE
Handle error in event index pipeline when a term is blank

### DIFF
--- a/cdp_backend/pipeline/generate_event_index_pipeline.py
+++ b/cdp_backend/pipeline/generate_event_index_pipeline.py
@@ -248,6 +248,11 @@ def read_transcripts_and_generate_grams(
                             closest_term = term
                             closest_term_score = similarity
 
+                    # If the closest term is blank, skip processing this item
+                    # Otherwise this throws an error 
+                    if closest_term == "":
+                        continue
+
                     # Get surrounding terms
                     terms = sm.original_details.text.split()
                     target_term_index = terms.index(closest_term)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves an issue I identified and shared on Slack. 

### Description of Changes

This PR adds an if statement to generate_event_index_pipeline.py. When a sentence contains a "-" character, it winds up being evaluated as a "" value, which then causes an error on line 254:

```
target_term_index = terms.index(closest_term)
```

This causes the entire event index operation to fail, and the only option to restore index functionality is to remove the event that caused the issue. This PR allows event index to continue, skipping that term. 