### PR TITLE
#239: bug/firestore_native_mode - in deploy, ensuring firestore database is configured in native mode

### DIFF
--- a/cdp_backend/infrastructure/Justfile
+++ b/cdp_backend/infrastructure/Justfile
@@ -87,6 +87,7 @@ deploy project cookiecutter_yaml=default_cookiecutter_yaml:
 	just enable-services
 	firebase use --add {{project}}
 	firebase deploy --only firestore:rules
+	gcloud alpha firestore databases update --type=firestore-native
 	firebase deploy --only firestore:indexes
 	firebase deploy --only storage
 	store_cdp_metadata_document {{cookiecutter_yaml}}


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #239 

### Description of Changes

Adds call to:

`gcloud alpha firestore databases update --type=firestore-native`

in the `deploy` workflow in the `Justfile`.  Has not been tested!  And might be better situated more immediately after the creation of the firestore database in the `setup` workflow.  But I just placed it in the location identified in the related issue as when the issue arises, so it should be fine as is.
